### PR TITLE
Fixed warnings in maven build.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,8 @@
                 <!-- Assembly -->
                 <plugin>
                     <artifactId>maven-assembly-plugin</artifactId>
-                    <version>2.2.1</version>
+                    <!-- update to 2.4.1 to avoid packaging warnings -->
+                    <version>2.4.1</version>
                 </plugin>
 
                 <!-- Unit tests -->
@@ -145,6 +146,13 @@
                 </execution>
             </executions>
         </plugin>
+        
+                <!-- Deploy -->
+                <plugin>
+                    <artifactId>maven-deploy-plugin</artifactId>
+                    <version>2.8.2</version>
+                </plugin>
+        
       </plugins>
 
         </pluginManagement>

--- a/tools/org.jupnp.tool/pom.xml
+++ b/tools/org.jupnp.tool/pom.xml
@@ -95,6 +95,13 @@
 					<descriptorRefs>
 						<descriptorRef>jar-with-dependencies</descriptorRef>
 					</descriptorRefs>
+					<finalName>jupnptool-${project.version}</finalName>
+					<!-- when do NOT append assemble id, do NOT attach to project artefacts -->
+					<!-- Otherwise you will see -->
+					<!-- [WARNING] Configuration options: ... Instead of attaching the assembly 
+						file: -->
+					<appendAssemblyId>false</appendAssemblyId>
+					<attach>false</attach>
 				</configuration>
 				<executions>
 					<execution>
@@ -103,13 +110,6 @@
 						<goals>
 							<goal>single</goal>
 						</goals>
-						<configuration>
-							<descriptorRefs>
-								<descriptorRef>jar-with-dependencies</descriptorRef>
-							</descriptorRefs>
-							<finalName>jupnptool-${version}</finalName>
-							<appendAssemblyId>false</appendAssemblyId>
-						</configuration>
 					</execution>
 				</executions>
 			</plugin>


### PR DESCRIPTION
- specify version of deploy plugin
- update assembly plugin to 2.4.1
- fixed jar-with-dependencies packages

Signed-off-by: Jochen Hiller jo.hiller@googlemail.com (github:
@jochenhiller)
