### PR TITLE
Fixed missing Import-Package for org.osgi.servic e.device

### DIFF
--- a/tests/devices/simple/pom.xml
+++ b/tests/devices/simple/pom.xml
@@ -49,6 +49,7 @@
 							org.osgi.framework,
 							org.osgi.service.event,
 							org.osgi.service.upnp,
+							org.osgi.service.device,
 							org.osgi.util.tracker
 						</Import-Package>
 						<Export-Package>


### PR DESCRIPTION
- build does run with this fix successfully again

Signed-off-by: Jochen Hiller jo.hiller@googlemail.com
