### PR TITLE
Fixed #043: Optimized initial thread pool size

### DIFF
--- a/bundles/org.jupnp/src/main/java/org/jupnp/DefaultUpnpServiceConfiguration.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/DefaultUpnpServiceConfiguration.java
@@ -89,6 +89,8 @@ public class DefaultUpnpServiceConfiguration implements UpnpServiceConfiguration
 
     private Logger log = Logger.getLogger(DefaultUpnpServiceConfiguration.class.getName());
 
+    /** we will use a core pool size of 1 as long as we allow to timeout core threads. */
+    final private static int CORE_THREAD_POOL_SIZE = 1;
     final private static int THREAD_POOL_SIZE = 200;
     final private static int THREAD_QUEUE_SIZE = 1000;
     
@@ -326,7 +328,7 @@ public class DefaultUpnpServiceConfiguration implements UpnpServiceConfiguration
 
         public JUPnPExecutor(ThreadFactory threadFactory, RejectedExecutionHandler rejectedHandler) {
             // This is the same as Executors.newCachedThreadPool
-            super(THREAD_POOL_SIZE,
+            super(CORE_THREAD_POOL_SIZE,
             	  THREAD_POOL_SIZE,
                   10L,
                   TimeUnit.SECONDS,

--- a/bundles/org.jupnp/src/main/java/org/jupnp/OSGiUpnpServiceConfiguration.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/OSGiUpnpServiceConfiguration.java
@@ -94,6 +94,9 @@ public class OSGiUpnpServiceConfiguration implements UpnpServiceConfiguration {
 
     private Logger log = LoggerFactory.getLogger(OSGiUpnpServiceConfiguration.class);
 
+    /** we will use a core pool size of 1 as long as we allow to timeout core threads. */
+    final private static int CORE_THREAD_POOL_SIZE = 1;
+
     // configurable properties
     private int threadPoolSize = 200;
     private int threadQueueSize = 1000;
@@ -377,7 +380,7 @@ public class OSGiUpnpServiceConfiguration implements UpnpServiceConfiguration {
 
         public JUPnPExecutor(ThreadFactory threadFactory, RejectedExecutionHandler rejectedHandler) {
             // This is the same as Executors.newCachedThreadPool
-            super(threadPoolSize, threadPoolSize, 10L, TimeUnit.SECONDS,
+            super(CORE_THREAD_POOL_SIZE, threadPoolSize, 10L, TimeUnit.SECONDS,
                     new ArrayBlockingQueue<Runnable>(threadQueueSize), threadFactory, rejectedHandler);
             allowCoreThreadTimeOut(true);
         }


### PR DESCRIPTION
* core pool size is now 3
* can be configured in OSGi by ConfigAdmin

Signed-off-by: Jochen Hiller <jo.hiller@googlemail.com>