### PR TITLE
Added tests for QueueingThreadPoolExecutor

### DIFF
--- a/bundles/org.jupnp/src/main/java/org/jupnp/QueueingThreadPoolExecutor.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/QueueingThreadPoolExecutor.java
@@ -73,6 +73,13 @@ public class QueueingThreadPoolExecutor extends ThreadPoolExecutor {
 
     final private String threadPoolName;
 
+    /**
+     * Allows to subclass QueueingThreadPoolExecutor
+     */
+    protected QueueingThreadPoolExecutor(String name, int threadPoolSize) {
+        this(name, new CommonThreadFactory(name), threadPoolSize, new QueueingThreadPoolExecutor.QueueingRejectionHandler());
+    }
+
     private QueueingThreadPoolExecutor(String threadPoolName, ThreadFactory threadFactory, int threadPoolSize,
             RejectedExecutionHandler rejectionHandler) {
         super(CORE_THREAD_POOL_SIZE, threadPoolSize, 10L, TimeUnit.SECONDS, new SynchronousQueue<Runnable>(),
@@ -197,7 +204,7 @@ public class QueueingThreadPoolExecutor extends ThreadPoolExecutor {
      * This is the internally used rejection handler, which - instead of rejecting a task - puts it to the queue of the
      * pool.
      */
-    static private class QueueingRejectionHandler extends ThreadPoolExecutor.DiscardPolicy {
+    private static class QueueingRejectionHandler extends ThreadPoolExecutor.DiscardPolicy {
 
         @Override
         public void rejectedExecution(Runnable runnable, ThreadPoolExecutor threadPoolExecutor) {

--- a/tests/core/src/test/java/org/jupnp/test/service/QueueingThreadPoolExecutorTest.java
+++ b/tests/core/src/test/java/org/jupnp/test/service/QueueingThreadPoolExecutorTest.java
@@ -1,0 +1,860 @@
+/**
+ * Copyright (C) 2014 4th Line GmbH, Switzerland and others
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License Version 1 or later
+ * ("CDDL") (collectively, the "License"). You may not use this file
+ * except in compliance with the License. See LICENSE.txt for more
+ * information.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ */
+package org.jupnp.test.service;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotEquals;
+import static org.testng.Assert.assertTrue;
+
+import java.security.Permission;
+import java.util.Random;
+import java.util.concurrent.SynchronousQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
+
+import org.jupnp.QueueingThreadPoolExecutor;
+
+/**
+ * Test class for the {@link QueueingThreadPoolExecutor} class, abbreviated here
+ * QueueingTPE.
+ * 
+ * @author Jochen Hiller - Initial contribution
+ */
+public class QueueingThreadPoolExecutorTest {
+
+	/**
+	 * we know that the QueuingTPE uses a core pool timeout of 10 seconds. Will
+	 * be needed to check if all threads are down after this timeout.
+	 */
+	private final static int CORE_POOL_TIMEOUT = 10000;
+
+	/**
+	 * We can enable logging for all test cases.
+	 */
+	@BeforeTest
+	public void setUp() {
+		// enable to see logging. See below how to include slf4j-simple
+		// enableLogging();
+		disableLogging();
+	}
+
+	/**
+	 * Creates QueueingTPE instances. By default there will be NO thread
+	 * created, check it.
+	 */
+	@Test
+	public void testCreateInstance() {
+		String poolName = "testCreateInstance";
+		QueueingThreadPoolExecutor.createInstance(poolName, 1);
+		QueueingThreadPoolExecutor.createInstance(poolName, 2);
+		QueueingThreadPoolExecutor.createInstance(poolName, 5);
+		QueueingThreadPoolExecutor.createInstance(poolName, 10);
+		QueueingThreadPoolExecutor.createInstance(poolName, 1000);
+		QueueingThreadPoolExecutor.createInstance(poolName, 10000);
+		QueueingThreadPoolExecutor.createInstance(poolName, 100000);
+		QueueingThreadPoolExecutor.createInstance(poolName, 1000000);
+		// no threads created
+		assertFalse(areThreadsFromPoolRunning(poolName));
+	}
+
+	/**
+	 * Tests what happens when poolName == null.
+	 * 
+	 * @TODO should QTPE raise an IllegalArgumentException in that case?
+	 */
+	@Test
+	public void testCreateInstanceInvalidArgsPoolNameNull() throws InterruptedException {
+		String poolName = "null";
+		ThreadPoolExecutor pool = QueueingThreadPoolExecutor.createInstance(null, 1);
+		pool.execute(createRunnableFast());
+		assertTrue(isPoolThreadActive(poolName, 1));
+		pool.execute(createRunnableFast());
+		pool.execute(createRunnableFast());
+		pool.execute(createRunnableFast());
+		assertTrue(isQueueThreadActive(poolName));
+
+		// needs to wait CORE_POOL_TIMEOUT + 2sec-queue-thread + x until all
+		// threads are down again
+		pool.shutdown();
+		Thread.sleep(CORE_POOL_TIMEOUT + 3000);
+		assertFalse(areThreadsFromPoolRunning(poolName));
+	}
+
+	@Test(expectedExceptions = IllegalArgumentException.class)
+	public void testCreateInstanceInvalidArgsPoolSize0() {
+		QueueingThreadPoolExecutor.createInstance("test", 0);
+	}
+
+	@Test(expectedExceptions = IllegalArgumentException.class)
+	public void testCreateInstanceInvalidArgsPoolSizeMinus1() {
+		QueueingThreadPoolExecutor.createInstance("test", -1);
+	}
+
+	/**
+	 * This test tests behavior of standard TPE for a pool of core=1, max=2 when
+	 * no tasks have been scheduled. Acts as reference test case.
+	 */
+	@Test
+	public void testPlainTPEPoolSize2() throws InterruptedException {
+		ThreadPoolExecutor pool = new ThreadPoolExecutor(1, 2, 10L, TimeUnit.SECONDS, new SynchronousQueue<Runnable>());
+		pool.allowCoreThreadTimeOut(true);
+
+		assertEquals(pool.getActiveCount(), 0);
+		assertEquals(pool.allowsCoreThreadTimeOut(), true);
+		assertEquals(pool.getCompletedTaskCount(), 0);
+		assertEquals(pool.getCorePoolSize(), 1);
+		assertEquals(pool.getMaximumPoolSize(), 2);
+		assertEquals(pool.getLargestPoolSize(), 0);
+		assertEquals(pool.getQueue().size(), 0);
+
+		// there will be 1 core thread created. Will not check here
+
+		// needs to wait CORE_POOL_TIMEOUT + x until all threads are down again
+		pool.shutdown();
+		Thread.sleep(CORE_POOL_TIMEOUT + 1000);
+	}
+
+	/**
+	 * This test tests behavior of QueueingTPE for a pool of core=1, max=2 when
+	 * no tasks have been scheduled. Same assumptions as above.
+	 */
+	@Test
+	public void testQueuingTPEPoolSize2() throws InterruptedException {
+		String poolName = "testQueuingTPEPoolSize2";
+		ThreadPoolExecutor pool = QueueingThreadPoolExecutor.createInstance(poolName, 2);
+
+		assertEquals(pool.getActiveCount(), 0);
+		assertEquals(pool.allowsCoreThreadTimeOut(), true);
+		assertEquals(pool.getCompletedTaskCount(), 0);
+		assertEquals(pool.getCorePoolSize(), 1);
+		assertEquals(pool.getMaximumPoolSize(), 2);
+		assertEquals(pool.getLargestPoolSize(), 0);
+		assertEquals(pool.getQueue().size(), 0);
+
+		// now expect that no threads have been created
+		assertFalse(areThreadsFromPoolRunning(poolName));
+
+		// no need to wait after shutdown as no threads created
+		pool.shutdown();
+	}
+
+	@Test
+	public void testPoolWithWellDefinedPoolName() throws InterruptedException {
+		basicTestForPoolName("testPoolWithWellDefinedPoolName");
+	}
+
+	@Test
+	public void testPoolWithBlankPoolName() throws InterruptedException {
+		basicTestForPoolName(" ");
+	}
+
+	@Test
+	public void testPoolWithEmptyPoolName() throws InterruptedException {
+		basicTestForPoolName("");
+	}
+
+	/**
+	 * Basic tests of a pool with a given name. Checks thread creation and
+	 * cleanup.
+	 */
+	protected void basicTestForPoolName(String poolName) throws InterruptedException {
+		ThreadPoolExecutor pool = QueueingThreadPoolExecutor.createInstance(poolName, 2);
+		pool.execute(createRunnable100ms());
+		pool.execute(createRunnable100ms());
+		assertTrue(isPoolThreadActive(poolName, 1));
+		assertTrue(isPoolThreadActive(poolName, 2));
+
+		// no queue thread
+
+		// needs to wait CORE_POOL_TIMEOUT + x until all threads are down again
+		pool.shutdown();
+		Thread.sleep(CORE_POOL_TIMEOUT + 1000);
+		assertFalse(areThreadsFromPoolRunning(poolName));
+	}
+
+	@Test
+	public void testPoolSize1() throws InterruptedException {
+		String poolName = "testPoolSize1";
+		ThreadPoolExecutor pool = QueueingThreadPoolExecutor.createInstance(poolName, 1);
+
+		pool.execute(createRunnable100ms());
+		assertEquals(pool.getActiveCount(), 1);
+
+		pool.execute(createRunnable100ms());
+		// queue thread must be active
+		assertTrue(isQueueThreadActive(poolName));
+		// after 1+x sec all should be executed
+		Thread.sleep(1000);
+		assertEquals(pool.getCompletedTaskCount(), 2);
+		// at the end queue thread is shutdown, wait for additional 3 sec
+		Thread.sleep(3000);
+		assertFalse(isQueueThreadActive(poolName));
+
+		pool.execute(createRunnable100ms());
+		pool.execute(createRunnable100ms());
+		assertTrue(isQueueThreadActive(poolName));
+		// after 1+x sec all should be executed
+		Thread.sleep(1000);
+		assertEquals(pool.getCompletedTaskCount(), 4);
+
+		// needs to wait CORE_POOL_TIMEOUT + 2sec-queue-thread + x until all
+		// threads are down again
+		pool.shutdown();
+		Thread.sleep(CORE_POOL_TIMEOUT + 3000);
+		assertFalse(areThreadsFromPoolRunning(poolName));
+	}
+
+	@Test
+	public void testPoolSize2ThreadsFast() throws InterruptedException {
+		String poolName = "testPoolSize2ThreadsFast";
+		ThreadPoolExecutor pool = QueueingThreadPoolExecutor.createInstance(poolName, 2);
+		pool.execute(createRunnableFast());
+		pool.execute(createRunnableFast());
+		Thread.sleep(1000);
+		assertEquals(pool.getCompletedTaskCount(), 2);
+
+		// no queue thread
+
+		// needs to wait CORE_POOL_TIMEOUT + x until all threads are down again
+		pool.shutdown();
+		Thread.sleep(CORE_POOL_TIMEOUT + 1000);
+		assertFalse(areThreadsFromPoolRunning(poolName));
+	}
+
+	@Test
+	public void testPoolSize1000ThreadsFast() throws InterruptedException {
+		AbstractRunnable.resetRuns();
+		String poolName = "testPoolSize1000ThreadsFast";
+		ThreadPoolExecutor pool = QueueingThreadPoolExecutor.createInstance(poolName, 1000);
+		for (int i = 0; i < 1000; i++) {
+			pool.execute(createRunnableFast());
+		}
+		// no queue thread
+		assertFalse(isQueueThreadActive(poolName));
+		Thread.sleep(1000);
+		assertEquals(pool.getCompletedTaskCount(), 1000);
+		assertEquals(AbstractRunnable.getRuns(), 1000);
+
+		// needs to wait CORE_POOL_TIMEOUT + x until all threads are down again
+		pool.shutdown();
+		Thread.sleep(CORE_POOL_TIMEOUT + 1000);
+		assertFalse(areThreadsFromPoolRunning(poolName));
+	}
+
+	@Test
+	public void testPoolSize2ThreadsHeavyLoad() throws InterruptedException {
+		String poolName = "testPoolSize2ThreadsHeavyLoad";
+		ThreadPoolExecutor pool = QueueingThreadPoolExecutor.createInstance(poolName, 2);
+		pool.execute(createRunnableHeavyLoad1s());
+		pool.execute(createRunnableHeavyLoad1s());
+		pool.execute(createRunnableHeavyLoad1s());
+		pool.execute(createRunnableHeavyLoad1s());
+
+		assertTrue(isQueueThreadActive(poolName));
+		Thread.sleep(5000);
+		assertEquals(pool.getCompletedTaskCount(), 4);
+
+		// needs to wait CORE_POOL_TIMEOUT + 2sec-queue-thread + x until all
+		// threads are down again
+		pool.shutdown();
+		Thread.sleep(CORE_POOL_TIMEOUT + 3000);
+		assertFalse(areThreadsFromPoolRunning(poolName));
+	}
+
+	@Test
+	public void testPoolSize2ThreadSettings() throws InterruptedException {
+		String poolName = "testPoolSize2ThreadSettings";
+		basicTestPoolSize2ThreadSettings(poolName);
+	}
+
+	/**
+	 * Tests using security manager with high max thread group priority.
+	 */
+	@Test
+	public void testPoolSize2ThreadSettingsWithSeurityManagerThreadGroupMaxPriority() throws InterruptedException {
+		SecurityManager sm = System.getSecurityManager();
+		try {
+			System.setSecurityManager(new SecurityManager() {
+				@Override
+				public void checkPermission(Permission perm) {
+				}
+
+				@Override
+				public ThreadGroup getThreadGroup() {
+					ThreadGroup g = new ThreadGroup("TestMaxThreadGroup");
+					g.setDaemon(true);
+					g.setMaxPriority(Thread.MAX_PRIORITY);
+					return g;
+				}
+			});
+			String poolName = "testPoolSize2ThreadSettingsWithSeurityManagerThreadGroupMaxPriority";
+			basicTestPoolSize2ThreadSettings(poolName);
+		} finally {
+			System.setSecurityManager(sm);
+		}
+	}
+
+	/**
+	 * Tests using security manager with low min thread group priority.
+	 */
+	@Test
+	public void testPoolSize2ThreadSettingsWithSeurityManagerThreadGroupMinPriority() throws InterruptedException {
+		SecurityManager sm = System.getSecurityManager();
+		try {
+			System.setSecurityManager(new SecurityManager() {
+				@Override
+				public void checkPermission(Permission perm) {
+				}
+
+				@Override
+				public ThreadGroup getThreadGroup() {
+					ThreadGroup g = new ThreadGroup("TestMinThreadGroup");
+					g.setDaemon(true);
+					g.setMaxPriority(Thread.MIN_PRIORITY);
+					return g;
+				}
+			});
+			String poolName = "testPoolSize2ThreadSettingsWithSeurityManagerThreadGroupMinPriority";
+			basicTestPoolSize2ThreadSettings(poolName);
+		} finally {
+			System.setSecurityManager(sm);
+		}
+	}
+
+	/**
+	 * Test basic thread creation, including thread settings (name, prio,
+	 * daemon).
+	 */
+	protected void basicTestPoolSize2ThreadSettings(String poolName) throws InterruptedException {
+		ThreadPoolExecutor pool = QueueingThreadPoolExecutor.createInstance(poolName, 2);
+
+		// pool 2 tasks, threads must exist
+		pool.execute(createRunnable10s());
+		assertEquals(pool.getActiveCount(), 1);
+		assertTrue(isPoolThreadActive(poolName, 1));
+		Thread t1 = getThread(poolName + "-1");
+		assertEquals(t1.isDaemon(), false);
+		// thread will be NORM prio or max prio of this thread group, which can
+		// < than NORM
+		int prio1 = Math.min(t1.getThreadGroup().getMaxPriority(), Thread.NORM_PRIORITY);
+		assertEquals(t1.getPriority(), prio1);
+
+		pool.execute(createRunnable10s());
+		assertEquals(pool.getActiveCount(), 2);
+		assertTrue(isPoolThreadActive(poolName, 2));
+		Thread t2 = getThread(poolName + "-2");
+		assertEquals(t2.isDaemon(), false);
+		// thread will be NORM prio or max prio of this thread group, which can
+		// < than NORM
+		int prio2 = Math.min(t2.getThreadGroup().getMaxPriority(), Thread.NORM_PRIORITY);
+		assertEquals(t2.getPriority(), prio2);
+
+		// 2 more tasks, will be queued, no threads
+		pool.execute(createRunnable1s());
+		// as pool size is 2, no more active threads, will stay at 2
+		assertEquals(pool.getActiveCount(), 2);
+		assertFalse(isPoolThreadActive(poolName, 3));
+		assertEquals(pool.getQueue().size(), 1);
+
+		pool.execute(createRunnable1s());
+		assertEquals(pool.getActiveCount(), 2);
+		assertFalse(isPoolThreadActive(poolName, 4));
+		assertEquals(pool.getQueue().size(), 2);
+
+		// 0 are yet executed
+		assertEquals(pool.getCompletedTaskCount(), 0);
+
+		// needs to wait CORE_POOL_TIMEOUT + 2sec-queue-thread + x until all
+		// threads are down again
+		pool.shutdown();
+		Thread.sleep(CORE_POOL_TIMEOUT + 3000);
+		assertFalse(areThreadsFromPoolRunning(poolName));
+	}
+
+	/**
+	 * Test that no further tasks will be executed when TPE is terminating.
+	 * 
+	 * @TODO the check for
+	 *       "(threadPoolExecutor instanceof QueueingThreadPoolExecutor)" is not
+	 *       necessary. This can never happen
+	 */
+	@Test
+	public void testShutdownNoEntriesIntoQueueAnymore() throws InterruptedException {
+		String poolName = "testShutdownNoEntriesIntoQueueAnymore";
+		ThreadPoolExecutor pool = QueueingThreadPoolExecutor.createInstance(poolName, 2);
+
+		pool.execute(createRunnable10s());
+		pool.execute(createRunnable10s());
+		pool.execute(createRunnable10s());
+		assertEquals(pool.getQueue().size(), 1);
+		pool.execute(createRunnable10s());
+		assertEquals(pool.getQueue().size(), 2);
+
+		// now shutdown, and check no more entries into pool
+		pool.shutdown();
+		// give chance to shutdown
+		Thread.sleep(1000);
+		assertEquals(pool.isShutdown(), true);
+		pool.execute(createRunnable10s());
+		// must stay at 2
+		assertEquals(pool.getQueue().size(), 2);
+
+		// 0 are executed
+		assertEquals(pool.getCompletedTaskCount(), 0);
+
+		// needs to wait CORE_POOL_TIMEOUT + 2sec-queue-thread + x until all
+		// threads are down again
+		// pool yet shutdown here
+		Thread.sleep(CORE_POOL_TIMEOUT + 3000);
+		assertFalse(areThreadsFromPoolRunning(poolName));
+	}
+
+	/**
+	 * Tests what happens when wrong rejected execution handler will be used.
+	 * 
+	 * @TODO better to override setRejectedExecutionHandler to NOT allow wrong
+	 *       one?
+	 */
+	@Test
+	public void testSetInvalidRejectionHandler() throws InterruptedException {
+		String poolName = "testShutdownNoEntriesIntoQueueAnymore";
+		ThreadPoolExecutor pool = QueueingThreadPoolExecutor.createInstance(poolName, 2);
+
+		pool.execute(createRunnable100ms());
+		pool.execute(createRunnable100ms());
+		pool.execute(createRunnable100ms());
+		pool.execute(createRunnable100ms());
+		assertEquals(pool.getActiveCount(), 2);
+		assertEquals(pool.getQueue().size(), 2);
+
+		// with wrong execution handler, further entries will be ignored
+		pool.setRejectedExecutionHandler(new ThreadPoolExecutor.DiscardPolicy());
+		pool.execute(createRunnableFast());
+		pool.execute(createRunnableFast());
+		assertEquals(pool.getQueue().size(), 2);
+
+		// needs to wait CORE_POOL_TIMEOUT + 2sec-queue-thread + x until all
+		// threads are down again
+		// pool yet shutdown here
+		Thread.sleep(CORE_POOL_TIMEOUT + 3000);
+		assertFalse(areThreadsFromPoolRunning(poolName));
+	}
+
+	/**
+	 * Test that interrupting queue thread does not loose tasks.
+	 */
+	@Test
+	public void testQueueThreadInterrupt() throws InterruptedException {
+		String poolName = "testQueueThreadInterrupt";
+		final ThreadPoolExecutor pool = QueueingThreadPoolExecutor.createInstance(poolName, 2);
+		long tStart;
+		long tEnd;
+
+		// interrupt when queue thread is started from current thread
+		for (int i = 0; i < 100; i++) {
+			pool.execute(createRunnable100ms());
+			Thread queueThread = getThread(poolName + "-queue");
+			if (queueThread != null) {
+				queueThread.interrupt();
+			}
+		}
+		assertEquals(pool.getQueue().size(), 98);
+		tStart = System.currentTimeMillis();
+		tEnd = tStart;
+		// wait for 10 sec
+		while ((tEnd - tStart) < 10000) {
+			// send interrupt very fast to jump into every piece of code
+			for (int j = 0; j < 100; j++) {
+				Thread queueThread = getThread(poolName + "-queue");
+				if (queueThread != null) {
+					queueThread.interrupt();
+				}
+			}
+			Thread.sleep(50); // chance for thread switch
+			tEnd = System.currentTimeMillis();
+		}
+		// chance to finalize queue thread
+		Thread.sleep(3000);
+		assertFalse(isQueueThreadActive(poolName));
+		// all should be executed
+		assertEquals(pool.getCompletedTaskCount(), 100);
+
+		// interrupt when queue thread is started from other threads
+		for (int i = 0; i < 100; i++) {
+			new Thread() {
+				public void run() {
+					pool.execute(createRunnable100ms());
+				}
+			}.start();
+			Thread queueThread = getThread(poolName + "-queue");
+			if (queueThread != null) {
+				queueThread.interrupt();
+			}
+		}
+		tStart = System.currentTimeMillis();
+		tEnd = tStart;
+		// wait for 10 sec
+		while ((tEnd - tStart) < 10000) {
+			// send interrupt very fast to jump into every piece of code
+			for (int j = 0; j < 100; j++) {
+				Thread queueThread = getThread(poolName + "-queue");
+				if (queueThread != null) {
+					queueThread.interrupt();
+				}
+			}
+			Thread.sleep(50); // chance for thread switch
+			tEnd = System.currentTimeMillis();
+		}
+		// chance to finalize
+		Thread.sleep(1000);
+		// all should be executed
+		assertEquals(pool.getCompletedTaskCount(), 200);
+
+		// needs to wait CORE_POOL_TIMEOUT + 2sec-queue-thread + x until all
+		// threads are down again
+		pool.shutdown();
+		Thread.sleep(CORE_POOL_TIMEOUT + 3000);
+		assertFalse(areThreadsFromPoolRunning(poolName));
+	}
+
+	/**
+	 * Tests large pool with long running tasks.
+	 */
+	@Test
+	public void testPoolSize10ThreadsLongNewQueueThread() throws InterruptedException {
+		String poolName = "testPoolSize10ThreadsLong";
+		ThreadPoolExecutor pool = QueueingThreadPoolExecutor.createInstance(poolName, 10);
+
+		for (int i = 0; i < 100; i++) {
+			pool.execute(createRunnable100ms());
+		}
+		assertEquals(pool.getActiveCount(), 10);
+		// queue thread must be active
+		assertTrue(isQueueThreadActive(poolName));
+		long queueThreadId1 = getThread(poolName + "-queue").getId();
+		// after 10+x sec all should be executed
+		Thread.sleep(12000);
+		assertEquals(pool.getCompletedTaskCount(), 100);
+		// at the end queue thread is shutdown, wait for additional 3 sec
+		Thread.sleep(3000);
+		assertFalse(isQueueThreadActive(poolName));
+
+		// now put again requests into queue. Queue thread should be created
+		// again with different thread id
+		for (int i = 0; i < 100; i++) {
+			pool.execute(createRunnable100ms());
+		}
+		assertTrue(isQueueThreadActive(poolName));
+		long queueThreadId2 = getThread(poolName + "-queue").getId();
+		// as queue thread has been created again, has to have different thread
+		// id
+		assertNotEquals(queueThreadId1, queueThreadId2);
+
+		// after 10+x sec all should be executed
+		Thread.sleep(12000);
+		assertEquals(pool.getCompletedTaskCount(), 200);
+		// at the end queue thread is shutdown, wait for additional 3 sec
+		Thread.sleep(3000);
+		assertFalse(isQueueThreadActive(poolName));
+
+		// needs to wait CORE_POOL_TIMEOUT + x until all
+		// threads are down again
+		pool.shutdown();
+		Thread.sleep(CORE_POOL_TIMEOUT + 1000);
+		assertFalse(areThreadsFromPoolRunning(poolName));
+	}
+
+	/**
+	 * This tests checks addToQueue() when used from multiple threads.
+	 */
+	@Test
+	public void testPoolSize10FillPoolParallel() throws InterruptedException {
+		String poolName = "testPoolSize10FillPoolParallel";
+		final ThreadPoolExecutor pool = QueueingThreadPoolExecutor.createInstance(poolName, 10);
+
+		Thread[] fillThreads = new Thread[100];
+		for (int i = 0; i < fillThreads.length; i++) {
+			fillThreads[i] = new Thread() {
+				@Override
+				public void run() {
+					pool.execute(createRunnable100ms());
+				}
+			};
+		}
+		// now start all threads
+		for (int i = 0; i < fillThreads.length; i++) {
+			fillThreads[i].start();
+		}
+		Thread.sleep(1000); // wait until filled
+
+		assertEquals(pool.getActiveCount(), 10);
+		// queue thread must be active
+		assertTrue(isQueueThreadActive(poolName));
+		// after 10+x sec all should be executed
+		Thread.sleep(12000);
+		assertEquals(pool.getCompletedTaskCount(), 100);
+		// at the end queue thread is shutdown, wait for additional 3 sec
+		Thread.sleep(3000);
+		assertFalse(isQueueThreadActive(poolName));
+
+		// needs to wait CORE_POOL_TIMEOUT + x until all
+		// threads are down again
+		pool.shutdown();
+		Thread.sleep(CORE_POOL_TIMEOUT + 1000);
+		assertFalse(areThreadsFromPoolRunning(poolName));
+	}
+
+	/**
+	 * Monkey test, just adding executors, and check if all have been executed.
+	 */
+	@Test
+	public void testMonkeyTest() throws InterruptedException {
+		AbstractRunnable.resetRuns();
+		String poolName = "testMonkeyTest";
+		final ThreadPoolExecutor pool = QueueingThreadPoolExecutor.createInstance(poolName, 5);
+
+		Thread[] fillThreads = new Thread[100];
+		for (int i = 0; i < fillThreads.length; i++) {
+			fillThreads[i] = new Thread() {
+				@Override
+				public void run() {
+					int action = new Random().nextInt(5);
+					switch (action) {
+					case 0:
+						pool.execute(createRunnableFast());
+						break;
+					case 1:
+						pool.execute(createRunnable100ms());
+						break;
+					case 2:
+						pool.execute(createRunnable1s());
+						break;
+					case 3:
+						pool.execute(createRunnable10s());
+						break;
+					case 4:
+						pool.execute(createRunnableHeavyLoad1s());
+						break;
+					}
+				}
+			};
+		}
+		// now start all threads
+		for (int i = 0; i < fillThreads.length; i++) {
+			fillThreads[i].start();
+		}
+		Thread.sleep(1000); // wait until filled
+
+		assertEquals(pool.getActiveCount(), 5);
+		// queue thread must be active
+		assertTrue(isQueueThreadActive(poolName));
+
+		// wait until processed
+		while (pool.getCompletedTaskCount() < 100) {
+			Thread.sleep(1000);
+		}
+		assertEquals(pool.getCompletedTaskCount(), 100);
+		// check runs too
+		assertEquals(AbstractRunnable.getRuns(), 100);
+
+		// needs to wait CORE_POOL_TIMEOUT + 2sec-queue-thread + x until all
+		// threads are down again
+		pool.shutdown();
+		Thread.sleep(CORE_POOL_TIMEOUT + 3000);
+		assertFalse(areThreadsFromPoolRunning(poolName));
+	}
+
+	// helper methods
+
+	private void enableLogging() {
+		// add slf4j-simple-1.7.13.jar to classpath to activate logging during
+		// development
+		// e.g. from http://mvnrepository.com/artifact/org.slf4j/slf4j-simple
+		System.setProperty("org.slf4j.simpleLogger.defaultLogLevel", "trace");
+		System.setProperty("org.slf4j.simpleLogger.logFile", "System.out");
+		System.setProperty("org.slf4j.simpleLogger.showDateTime", "true");
+	}
+
+	private void disableLogging() {
+		// disable logging
+		System.setProperty("org.slf4j.simpleLogger.defaultLogLevel", "error");
+		System.clearProperty("org.slf4j.simpleLogger.logFile");
+		System.clearProperty("org.slf4j.simpleLogger.showDateTime");
+	}
+
+	private boolean isQueueThreadActive(String poolName) {
+		return getThread(poolName + "-queue") != null;
+	}
+
+	private boolean isPoolThreadActive(String poolName, int id) {
+		return getThread(poolName + "-" + id) != null;
+	}
+
+	/**
+	 * Search for thread with given name.
+	 * 
+	 * @return found thread or null
+	 */
+	private Thread getThread(String threadName) {
+		// get top level thread group
+		ThreadGroup g = Thread.currentThread().getThreadGroup();
+		while (g.getParent() != null) {
+			g = g.getParent();
+		}
+		// make buffer 10 entries bigger
+		Thread[] l = new Thread[g.activeCount() + 10];
+		int n = g.enumerate(l);
+		for (int i = 0; i < n; i++) {
+			// enable printout to see threads
+			// System.out.println("getThread:" + l[i]);
+			if (l[i].getName().equals(threadName)) {
+				return l[i];
+			}
+		}
+		return null;
+	}
+
+	private boolean areThreadsFromPoolRunning(String poolName) {
+		// get top level thread group
+		ThreadGroup g = Thread.currentThread().getThreadGroup();
+		while (g.getParent() != null) {
+			g = g.getParent();
+		}
+		boolean foundThreads = false;
+		// make buffer 10 entries bigger
+		Thread[] l = new Thread[g.activeCount() + 10];
+		int n = g.enumerate(l);
+		for (int i = 0; i < n; i++) {
+			// we can only test if name is at least one character,
+			// otherwise there will be threads found (handles poolName="")
+			if (poolName.length() > 0) {
+				if (l[i].getName().startsWith(poolName)) {
+					// enable printout to see threads
+					// System.out.println("areThreadsFromPoolRunning: " +
+					// l[i].toString());
+					foundThreads = true;
+				}
+			}
+		}
+		return foundThreads;
+	}
+
+	// Runnables for testing
+
+	private Runnable createRunnableFast() {
+		return new RunnableFast();
+	}
+
+	private Runnable createRunnable100ms() {
+		return new Runnable100ms();
+	}
+
+	private Runnable createRunnable1s() {
+		return new Runnable1s();
+	}
+
+	private Runnable createRunnable10s() {
+		return new Runnable10s();
+	}
+
+	private Runnable createRunnableHeavyLoad1s() {
+		return new RunnableHeavyLoad1s();
+	}
+
+	private static abstract class AbstractRunnable implements Runnable {
+		private static AtomicInteger runs = new AtomicInteger(0);
+
+		public static void resetRuns() {
+			runs = new AtomicInteger(0);
+		}
+
+		public static int getRuns() {
+			return runs.get();
+		}
+
+		protected Logger logger = LoggerFactory.getLogger(this.getClass());
+
+		protected void sleep(int milliseconds) {
+			try {
+				Thread.sleep(milliseconds);
+			} catch (InterruptedException e) {
+				// ignore
+				logger.info("interrupted");
+			}
+		}
+
+		public void run() {
+			logger.info("run");
+			runs.incrementAndGet();
+		}
+	}
+
+	private static class RunnableFast extends AbstractRunnable {
+		@Override
+		public void run() {
+			super.run();
+			// do nothing
+		}
+	}
+
+	private static class RunnableHeavyLoad1s extends AbstractRunnable {
+		/** preserve as static to avoid code optimization. */
+		static double d = Math.PI;
+
+		@Override
+		public void run() {
+			super.run();
+			long tStart = System.currentTimeMillis();
+			long tEnd = tStart;
+			while ((tEnd - tStart) < 1000) {
+				for (int i = 0; i < 10000; i++) {
+					d += Math.acos((double) tEnd);
+					d += Math.atan(Math.sqrt(Math.pow(d, 10)));
+				}
+				tEnd = System.currentTimeMillis();
+			}
+		}
+	}
+
+	private static class Runnable100ms extends AbstractRunnable {
+		@Override
+		public void run() {
+			super.run();
+			sleep(100);
+		}
+	}
+
+	private static class Runnable1s extends AbstractRunnable {
+		@Override
+		public void run() {
+			super.run();
+			sleep(1 * 1000);
+		}
+	}
+
+	private static class Runnable10s extends AbstractRunnable {
+		@Override
+		public void run() {
+			super.run();
+			sleep(10 * 1000);
+		}
+	}
+}

--- a/tools/org.jupnp.tool/src/main/java/org/jupnp/tool/cli/CommandLineArgs.java
+++ b/tools/org.jupnp.tool/src/main/java/org/jupnp/tool/cli/CommandLineArgs.java
@@ -38,8 +38,8 @@ public class CommandLineArgs {
 	public Integer multicastResponsePort = 0;
 
 	@Parameter(names = { "--pool",
-			"-p" }, description = "Configure thread pools and enable pool statistic (corePoolsize,maxPoolSize,queueSize,timeout[,stats]) ", validateWith = MainCommandPoolConfigurationValidator.class)
-	public String poolConfig = "100,200,100,1000ms";
+			"-p" }, description = "Configure thread pools and enable pool statistic (mainPoolSize,asyncPoolSize[,stats]) ", validateWith = MainCommandPoolConfigurationValidator.class)
+	public String poolConfig = "20,40";
 	public static final String POOL_CONFIG_STATS_OPTION = "stats";
 
 	@Parameter(names = { "--verbose", "-v" }, description = "Enable verbose messages")

--- a/tools/org.jupnp.tool/src/main/java/org/jupnp/tool/cli/JUPnPTool.java
+++ b/tools/org.jupnp.tool/src/main/java/org/jupnp/tool/cli/JUPnPTool.java
@@ -191,23 +191,10 @@ public class JUPnPTool {
 		// sets the pool configuration
 		if (poolConfiguration != null) {
 			StringTokenizer tokenizer = new StringTokenizer(poolConfiguration, ",");
-			int core = Integer.valueOf(tokenizer.nextToken()).intValue();
-			int max = Integer.valueOf(tokenizer.nextToken()).intValue();
-			int queue = Integer.valueOf(tokenizer.nextToken()).intValue();
-			String timeoutAsString = tokenizer.nextToken().trim();
-			long timeout = 10000L; // in ms
-			if (timeoutAsString.endsWith("ms")) {
-				timeoutAsString = timeoutAsString.substring(0, timeoutAsString.indexOf("ms")).trim();
-				timeout = Integer.valueOf(timeoutAsString) * 1L;
-			} else if (timeoutAsString.endsWith("s")) {
-				timeoutAsString = timeoutAsString.substring(0, timeoutAsString.indexOf("s")).trim();
-				timeout = Integer.valueOf(timeoutAsString) * 1000L;
-			} else if (timeoutAsString.endsWith("m")) {
-				timeoutAsString = timeoutAsString.substring(0, timeoutAsString.indexOf("m")).trim();
-				timeout = Integer.valueOf(timeoutAsString) * 60L * 1000L;
-			}
+			int mainPoolSize = Integer.valueOf(tokenizer.nextToken()).intValue();
+			int asyncPoolSize = Integer.valueOf(tokenizer.nextToken()).intValue();
 
-			CmdlineUPnPServiceConfiguration.setPoolConfiguration(core, max, queue, timeout);
+			CmdlineUPnPServiceConfiguration.setPoolConfiguration(mainPoolSize, asyncPoolSize);
 			// one token left for stats option?
 			String stats = tokenizer.countTokens() == 1 ? tokenizer.nextToken() : null;
 			if (CommandLineArgs.POOL_CONFIG_STATS_OPTION.equalsIgnoreCase(stats)) {

--- a/tools/org.jupnp.tool/src/main/java/org/jupnp/tool/cli/MainCommandPoolConfigurationValidator.java
+++ b/tools/org.jupnp.tool/src/main/java/org/jupnp/tool/cli/MainCommandPoolConfigurationValidator.java
@@ -26,48 +26,23 @@ import com.beust.jcommander.ParameterException;
 public class MainCommandPoolConfigurationValidator implements IParameterValidator {
 
 	private final static String ERROR_MSG = "Paramer --pool must be of format "
-			+ "'<corePoolSize>,<maxPoolSize>,<queueSize>,<timeout>{ms|s|m}[,stats]'";
+			+ "'<mainPoolSize>,<asyncPoolSize>[,stats]'";
 
 	public void validate(String name, String value) throws ParameterException {
 		if (name.equals("--pool")) {
-			// pool config is sth like "20,40,1000,stats"
+			// pool config is sth like "20,20,stats"
 			StringTokenizer tokenizer = new StringTokenizer(value, ",");
-			// must have 3..4 args
-			if ((tokenizer.countTokens() < 4) || (tokenizer.countTokens() > 5)) {
-				throw new ParameterException(ERROR_MSG + " (not 4 or 5 parameters)");
+			// must have 2..3 args
+			if ((tokenizer.countTokens() < 2) || (tokenizer.countTokens() > 3)) {
+				throw new ParameterException(ERROR_MSG + " (not 2 or 3 parameters)");
 			} else {
 				try {
-					int corePoolSize = new Integer(tokenizer.nextToken()).intValue();
-					int maxPoolSize = new Integer(tokenizer.nextToken()).intValue();
-					int queueSize = new Integer(tokenizer.nextToken()).intValue();
-
-					String timeoutAsString = tokenizer.nextToken().trim();
-					long timeout = 10000L; // in ms
-					if (timeoutAsString.endsWith("ms")) {
-						String s = timeoutAsString.substring(0, timeoutAsString.indexOf("ms")).trim();
-						timeout = Integer.valueOf(s) * 1L;
-					} else if (timeoutAsString.endsWith("s")) {
-						String s = timeoutAsString.substring(0, timeoutAsString.indexOf("s")).trim();
-						timeout = Integer.valueOf(s) * 1000L;
-					} else if (timeoutAsString.endsWith("m")) {
-						String s = timeoutAsString.substring(0, timeoutAsString.indexOf("m")).trim();
-						timeout = Integer.valueOf(s) * 60L * 1000L;
-					} else {
-						// we assume ms as default
-						timeout = Integer.valueOf(timeoutAsString) * 1L;
-					}
+					int mainPoolSize = new Integer(tokenizer.nextToken()).intValue();
+					int asyncPoolSize = new Integer(tokenizer.nextToken()).intValue();
 
 					// all >0
-					if ((corePoolSize <= 0) || (maxPoolSize <= 0) || (queueSize <= 0)) {
+					if ((mainPoolSize <= 0) || (asyncPoolSize <= 0)) {
 						throw new ParameterException(ERROR_MSG + " (all values must be greater than 0)");
-					}
-					// core < max
-					if (corePoolSize > maxPoolSize) {
-						throw new ParameterException(ERROR_MSG + " (max must be greater than core)");
-					}
-					// timeout >0
-					if (timeout <= 0L) {
-						throw new ParameterException(ERROR_MSG + " (timeout must be greater than 0)");
 					}
 					// one token left?
 					if (tokenizer.countTokens() == 1) {

--- a/tools/org.jupnp.tool/src/main/java/org/jupnp/tool/cli/MonitoredQueueingThreadPoolExecutor.java
+++ b/tools/org.jupnp.tool/src/main/java/org/jupnp/tool/cli/MonitoredQueueingThreadPoolExecutor.java
@@ -1,0 +1,178 @@
+package org.jupnp.tool.cli;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.jupnp.QueueingThreadPoolExecutor;
+import org.jupnp.util.Exceptions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This class extends the {@link QueueingThreadPoolExecutor} about monitoring of
+ * tasks executed.
+ */
+public class MonitoredQueueingThreadPoolExecutor extends QueueingThreadPoolExecutor {
+
+	static boolean DEBUG_STATISTICS = false;
+
+	/** Statistical data collected. */
+	private MonitoredQueueingThreadPoolExecutor.Statistics stats;
+
+	static final transient Logger logger = LoggerFactory.getLogger(MonitoredQueueingThreadPoolExecutor.class);
+	static final transient Logger statsLogger = LoggerFactory.getLogger("org.jupnp.tool.cli.stats");
+
+	public MonitoredQueueingThreadPoolExecutor(String poolName, int threadPoolSize) {
+		super(poolName, threadPoolSize);
+		logger.debug("Created MonitoredQueueingThreadPoolExecutor with poolName=" + poolName + " and poolSize="
+				+ threadPoolSize);
+		if (DEBUG_STATISTICS) {
+			stats = new Statistics(poolName);
+		}
+	}
+
+	@Override
+	protected void beforeExecute(Thread t, Runnable r) {
+		if (DEBUG_STATISTICS) {
+			stats.addCurrentPoolSize(this);
+			stats.addExcecutor(r);
+		}
+		// TODO why so much executors?
+		// if (getQueue().size() > 100) {
+		// System.out.println("ALERT");
+		// }
+		super.beforeExecute(t, r);
+	}
+
+	@Override
+	protected void afterExecute(Runnable runnable, Throwable throwable) {
+		super.afterExecute(runnable, throwable);
+		if (throwable != null) {
+			Throwable cause = Exceptions.unwrap(throwable);
+			if ((cause instanceof InterruptedException) && isTerminating()) {
+				// Ignore this, might happen when we shutdownNow() the
+				// executor. We can't
+				// log at this point as the logging system might be stopped
+				// already (e.g. if it's a CDI component).
+				return;
+			}
+			// Log only
+			logger.warn("Thread terminated " + runnable + " abruptly with exception: " + throwable);
+			logger.warn("  Root cause: " + cause);
+		}
+	}
+
+	@Override
+	public void shutdown() {
+		logger.info("shutdown");
+		super.shutdown();
+		if (DEBUG_STATISTICS) {
+			stats.dumpPoolStats();
+			stats.dumpExecutorsStats();
+			stats.release();
+		}
+		logger.info("shutdown done");
+	}
+
+	@Override
+	public List<Runnable> shutdownNow() {
+		logger.info("shutdownNow");
+		List<Runnable> res = super.shutdownNow();
+		if (DEBUG_STATISTICS) {
+			stats.dumpPoolStats();
+			stats.dumpExecutorsStats();
+			stats.release();
+		}
+		logger.info("shutdownNow done");
+		return res;
+	}
+
+	// inner classes for statistics
+
+	static class Statistics {
+
+		static class PoolStatPoint {
+			public long timestamp, completedTasks;
+			public int corePoolSize, poolSize, maxPoolSize, activeCounts, queueSize;
+		}
+
+		/** Thread safe collection for points. */
+		private List<Statistics.PoolStatPoint> points = new CopyOnWriteArrayList<Statistics.PoolStatPoint>();
+
+		/** Thread safe collection for executors. */
+		private ConcurrentHashMap<String, AtomicInteger> executors = new ConcurrentHashMap<String, AtomicInteger>();
+
+		private final String poolName;
+
+		Statistics(String name) {
+			poolName = name;
+		}
+
+		/**
+		 * Add info about current pool status.
+		 */
+		private void addCurrentPoolSize(ThreadPoolExecutor pool) {
+			Statistics.PoolStatPoint p = new PoolStatPoint();
+			p.timestamp = System.currentTimeMillis();
+			p.corePoolSize = pool.getCorePoolSize();
+			p.poolSize = pool.getPoolSize();
+			p.maxPoolSize = pool.getMaximumPoolSize();
+			p.activeCounts = pool.getActiveCount();
+			p.queueSize = pool.getQueue().size();
+			p.completedTasks = pool.getCompletedTaskCount();
+			points.add(p);
+		}
+
+		/**
+		 * Increase number of calls to this runnable (by class name).
+		 */
+		public void addExcecutor(Runnable r) {
+			executors.putIfAbsent(r.getClass().getName(), new AtomicInteger(0));
+			executors.get(r.getClass().getName()).incrementAndGet();
+		}
+
+		public void release() {
+			points = null;
+			executors = null;
+		}
+
+		public void dumpPoolStats() {
+			statsLogger.info("Dump Pool Statistics for poolName: " + poolName);
+			statsLogger.info("[timestamp,corePoolSize,poolSize,maxPoolSize,activeThreads,queueSize,completedTasks]");
+			for (Iterator<Statistics.PoolStatPoint> iter = points.iterator(); iter.hasNext();) {
+				Statistics.PoolStatPoint p = iter.next();
+				statsLogger.info("" + p.timestamp + "," + p.corePoolSize + "," + p.poolSize + "," + p.maxPoolSize + ","
+						+ p.activeCounts + "," + p.queueSize + "," + p.completedTasks);
+			}
+			statsLogger.info(" ");
+		}
+
+		public void dumpExecutorsStats() {
+			statsLogger.info("Dump Pool Executors for poolName: " + poolName);
+
+			List<ConcurrentHashMap.Entry<String, AtomicInteger>> entries = new ArrayList<ConcurrentHashMap.Entry<String, AtomicInteger>>(
+					executors.entrySet());
+			// sort the entries by number of calls
+			Collections.sort(entries, new Comparator<ConcurrentHashMap.Entry<String, AtomicInteger>>() {
+				public int compare(ConcurrentHashMap.Entry<String, AtomicInteger> a,
+						ConcurrentHashMap.Entry<String, AtomicInteger> b) {
+					return Integer.compare(b.getValue().get(), a.getValue().get());
+				}
+			});
+
+			statsLogger.info("[executorClassName,numberOfExecutes]");
+			for (ConcurrentHashMap.Entry<String, AtomicInteger> e : entries) {
+				statsLogger.info(e.getKey() + "," + e.getValue().get());
+			}
+			statsLogger.info(" ");
+		}
+
+	}
+}

--- a/tools/org.jupnp.tool/src/main/java/org/jupnp/tool/cli/PrintUtils.java
+++ b/tools/org.jupnp.tool/src/main/java/org/jupnp/tool/cli/PrintUtils.java
@@ -42,8 +42,9 @@ public class PrintUtils {
 		for (Iterator<String[]> iter = table.iterator(); iter.hasNext();) {
 			String[] line = iter.next();
 			for (int i = 0; i < line.length; i++) {
-				maxColumnSizes[i] = Math.max(maxColumnSizes[i],
-						line[i].length());
+				if (line[i] != null) {
+					maxColumnSizes[i] = Math.max(maxColumnSizes[i], line[i].length());
+				}
 			}
 		}
 		// now print

--- a/tools/org.jupnp.tool/src/test/java/org/jupnp/tool/cli/CommandLineTest.java
+++ b/tools/org.jupnp.tool/src/test/java/org/jupnp/tool/cli/CommandLineTest.java
@@ -143,82 +143,42 @@ public class CommandLineTest extends AbstractTestCase {
 
 	@Test
 	public void testPoolConfigurationsOK() {
-		checkCommandLine(tool, JUPnPTool.RC_OK, "--pool=20,40,1000,10000ms nop");
-		Assert.assertThat(CmdlineUPnPServiceConfiguration.THREAD_CORE_POOL_SIZE, is(20));
-		Assert.assertThat(CmdlineUPnPServiceConfiguration.THREAD_MAX_POOL_SIZE, is(40));
-		Assert.assertThat(CmdlineUPnPServiceConfiguration.THREAD_QUEUE_SIZE, is(1000));
-		Assert.assertThat(CmdlineUPnPServiceConfiguration.TIMEOUT_MILLI_SECONDS, is(10000L));
-		Assert.assertThat(CmdlineUPnPServiceConfiguration.DEBUG_STATISTICS, is(false));
-
-		checkCommandLine(tool, JUPnPTool.RC_OK, "--pool=20,40,1000,10s nop");
-		Assert.assertThat(CmdlineUPnPServiceConfiguration.TIMEOUT_MILLI_SECONDS, is(10000L));
-
-		checkCommandLine(tool, JUPnPTool.RC_OK, "--pool=20,40,1000,1m nop");
-		Assert.assertThat(CmdlineUPnPServiceConfiguration.TIMEOUT_MILLI_SECONDS, is(60L * 1000L));
-
-		checkCommandLine(tool, JUPnPTool.RC_OK, "-p=20,40,1000,1000ms nop");
-		Assert.assertThat(CmdlineUPnPServiceConfiguration.TIMEOUT_MILLI_SECONDS, is(1000L));
-
-		checkCommandLine(tool, JUPnPTool.RC_OK, "-p=20,20,1000,100ms nop");
-		Assert.assertThat(CmdlineUPnPServiceConfiguration.TIMEOUT_MILLI_SECONDS, is(100L));
-
-		checkCommandLine(tool, JUPnPTool.RC_OK, "-p=1,1,1,10ms nop");
-		Assert.assertThat(CmdlineUPnPServiceConfiguration.TIMEOUT_MILLI_SECONDS, is(10L));
-
-		checkCommandLine(tool, JUPnPTool.RC_OK, "--pool=20,40,1000,1ms,stats nop");
-		Assert.assertThat(CmdlineUPnPServiceConfiguration.TIMEOUT_MILLI_SECONDS, is(1L));
-
-		checkCommandLine(tool, JUPnPTool.RC_OK, "--pool=20,40,1000,10ms nop");
-		Assert.assertThat(CmdlineUPnPServiceConfiguration.TIMEOUT_MILLI_SECONDS, is(10L));
+		CmdlineUPnPServiceConfiguration.setDebugStatistics(false);
+		checkCommandLine(tool, JUPnPTool.RC_OK, "--pool=20,20 nop");
+		Assert.assertThat(CmdlineUPnPServiceConfiguration.MAIN_POOL_SIZE, is(20));
+		Assert.assertThat(CmdlineUPnPServiceConfiguration.ASYNC_POOL_SIZE, is(20));
+		Assert.assertThat(MonitoredQueueingThreadPoolExecutor.DEBUG_STATISTICS, is(false));
 	}
 
 	@Test
 	public void testPoolConfigurationsWrong() {
-		checkCommandLine(tool, JUPnPTool.RC_INVALID_OPTION, "--pool=20,40,1000 nop");
-		Assert.assertThat(err.toString(), containsString("(not 4 or 5 parameters)"));
-		resetStreams();
-
-		checkCommandLine(tool, JUPnPTool.RC_INVALID_OPTION, "--pool=20,40,1000 nop");
-		Assert.assertThat(err.toString(), containsString("(not 4 or 5 parameters)"));
+		checkCommandLine(tool, JUPnPTool.RC_INVALID_OPTION, "--pool=20,20,20,20 nop");
+		Assert.assertThat(err.toString(), containsString("(not 2 or 3 parameters)"));
 		resetStreams();
 
 		checkCommandLine(tool, JUPnPTool.RC_INVALID_OPTION, "--pool=20 nop");
-		Assert.assertThat(err.toString(), containsString("(not 4 or 5 parameters)"));
+		Assert.assertThat(err.toString(), containsString("(not 2 or 3 parameters)"));
 		resetStreams();
 
-		checkCommandLine(tool, JUPnPTool.RC_INVALID_OPTION, "-p=20,40 nop");
-		Assert.assertThat(err.toString(), containsString("(not 4 or 5 parameters)"));
-		resetStreams();
-
-		checkCommandLine(tool, JUPnPTool.RC_INVALID_OPTION, "-p=40,20,1000,10000ms nop");
-		Assert.assertThat(err.toString(), containsString("(max must be greater than core)"));
-		resetStreams();
-
-		checkCommandLine(tool, JUPnPTool.RC_INVALID_OPTION, "-p=0,0,0,10000ms nop");
+		checkCommandLine(tool, JUPnPTool.RC_INVALID_OPTION, "-p=0,0 nop");
 		Assert.assertThat(err.toString(), containsString("(all values must be greater than 0)"));
 		resetStreams();
 
-		checkCommandLine(tool, JUPnPTool.RC_INVALID_OPTION, "-p=-1,40,1000,10000ms nop");
+		checkCommandLine(tool, JUPnPTool.RC_INVALID_OPTION, "-p=-1,20 nop");
 		Assert.assertThat(err.toString(), containsString("(all values must be greater than 0)"));
 		resetStreams();
-		checkCommandLine(tool, JUPnPTool.RC_INVALID_OPTION, "-p=20,-1,1000,10000ms nop");
-		Assert.assertThat(err.toString(), containsString("(all values must be greater than 0)"));
-		resetStreams();
-		checkCommandLine(tool, JUPnPTool.RC_INVALID_OPTION, "-p=20,40,-1,10000ms nop");
+		checkCommandLine(tool, JUPnPTool.RC_INVALID_OPTION, "-p=20,-1 nop");
 		Assert.assertThat(err.toString(), containsString("(all values must be greater than 0)"));
 		resetStreams();
 
-		checkCommandLine(tool, JUPnPTool.RC_INVALID_OPTION, "--pool=20A,40,1000,10000ms nop");
+		checkCommandLine(tool, JUPnPTool.RC_INVALID_OPTION, "--pool=20A,40 nop");
 		Assert.assertThat(err.toString(), containsString("(numbers wrong)"));
 		resetStreams();
-		checkCommandLine(tool, JUPnPTool.RC_INVALID_OPTION, "--pool=20,4B0,1000,10000ms nop");
-		Assert.assertThat(err.toString(), containsString("(numbers wrong)"));
-		resetStreams();
-		checkCommandLine(tool, JUPnPTool.RC_INVALID_OPTION, "--pool=20,40,C1000,10000ms nop");
+		checkCommandLine(tool, JUPnPTool.RC_INVALID_OPTION, "--pool=20,4B0 nop");
 		Assert.assertThat(err.toString(), containsString("(numbers wrong)"));
 		resetStreams();
 
-		checkCommandLine(tool, JUPnPTool.RC_INVALID_OPTION, "--pool=20,40,1000,10000ms,WRONGOPTIONS nop");
+		checkCommandLine(tool, JUPnPTool.RC_INVALID_OPTION, "--pool=20,40,WRONGOPTIONS nop");
 		Assert.assertThat(err.toString(), containsString("(only stats allowed as last option)"));
 		resetStreams();
 	}

--- a/tools/org.jupnp.tool/src/test/java/org/jupnp/tool/cli/SearchCommandTest.java
+++ b/tools/org.jupnp.tool/src/test/java/org/jupnp/tool/cli/SearchCommandTest.java
@@ -75,6 +75,11 @@ public class SearchCommandTest extends AbstractTestCase {
 	}
 
 	@Test
+	public void testSearchNoSortWithStatistics() {
+		checkCommandLine(tool, JUPnPTool.RC_OK, "--pool=20,40,stats search");
+	}
+
+	@Test
 	public void testSearchSortByIp() {
 		// checkCommandLine(tool, JUPnPTool.RC_OK, "--loglevel=INFO search");
 		checkCommandLine(tool, JUPnPTool.RC_OK, "search --timeout=20 --sort=ip");


### PR DESCRIPTION
I added tests for the QueueingThreadPoolExecutor. No bugs found in implementation, very good!

When writing tests 3 questions came up due to the current implementation:

* What shall happen when calling QueueingTPE with poolName==null?
* The code in rejection handler "if (threadPoolExecutor instanceof QueueingThreadPoolExecutor)" will never fail. Can be removed
* What shall happen if someone sets its own rejection handler? Maybe override this method and do NOT allow to do that (throw operation not allowed), as it would break correct working of the QueueingTPE

The tests take up to 5 min, because they will check if all threads will be cleaned up correctly. I added them to the test suite (by putting them to org.jupnp.test.service), which will slow down the tests. Shall I take them out here?

The tests have some timing conditions which did run well on development machine. It may behave different on a build server where other jobs are running in parallel. This needs to be tested.

Signed-off-by: Jochen Hiller <jo.hiller@googlemail.com>