### PR TITLE
Adapted jupnptool to new QueueingThreadPoolExecutor

### DIFF
--- a/bundles/org.jupnp/src/main/java/org/jupnp/QueueingThreadPoolExecutor.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/QueueingThreadPoolExecutor.java
@@ -73,6 +73,13 @@ public class QueueingThreadPoolExecutor extends ThreadPoolExecutor {
 
     final private String threadPoolName;
 
+    /**
+     * Allows to subclass QueueingThreadPoolExecutor.
+     */
+    protected QueueingThreadPoolExecutor(String name, int threadPoolSize) {
+        this(name, new CommonThreadFactory(name), threadPoolSize, new QueueingThreadPoolExecutor.QueueingRejectionHandler());
+    }
+
     private QueueingThreadPoolExecutor(String threadPoolName, ThreadFactory threadFactory, int threadPoolSize,
             RejectedExecutionHandler rejectionHandler) {
         super(CORE_THREAD_POOL_SIZE, threadPoolSize, 10L, TimeUnit.SECONDS, new SynchronousQueue<Runnable>(),
@@ -197,7 +204,7 @@ public class QueueingThreadPoolExecutor extends ThreadPoolExecutor {
      * This is the internally used rejection handler, which - instead of rejecting a task - puts it to the queue of the
      * pool.
      */
-    static private class QueueingRejectionHandler extends ThreadPoolExecutor.DiscardPolicy {
+    private static class QueueingRejectionHandler extends ThreadPoolExecutor.DiscardPolicy {
 
         @Override
         public void rejectedExecution(Runnable runnable, ThreadPoolExecutor threadPoolExecutor) {

--- a/tools/org.jupnp.tool/src/main/java/org/jupnp/tool/cli/CommandLineArgs.java
+++ b/tools/org.jupnp.tool/src/main/java/org/jupnp/tool/cli/CommandLineArgs.java
@@ -38,8 +38,8 @@ public class CommandLineArgs {
 	public Integer multicastResponsePort = 0;
 
 	@Parameter(names = { "--pool",
-			"-p" }, description = "Configure thread pools and enable pool statistic (corePoolsize,maxPoolSize,queueSize,timeout[,stats]) ", validateWith = MainCommandPoolConfigurationValidator.class)
-	public String poolConfig = "100,200,100,1000ms";
+			"-p" }, description = "Configure thread pools and enable pool statistic (mainPoolSize,asyncPoolSize[,stats]) ", validateWith = MainCommandPoolConfigurationValidator.class)
+	public String poolConfig = "20,40";
 	public static final String POOL_CONFIG_STATS_OPTION = "stats";
 
 	@Parameter(names = { "--verbose", "-v" }, description = "Enable verbose messages")

--- a/tools/org.jupnp.tool/src/main/java/org/jupnp/tool/cli/CommandLineArgs.java
+++ b/tools/org.jupnp.tool/src/main/java/org/jupnp/tool/cli/CommandLineArgs.java
@@ -58,7 +58,7 @@ public class CommandLineArgs {
 class SearchCommandArgs {
 
 	@Parameter(names = { "--timeout", "-t" }, description = "The timeout when search will be finished")
-	public Integer timeout = 10;
+	public Integer timeout = 20;
 
 	@Parameter(names = { "--sort",
 			"-s" }, description = "Sort using {none|ip|model|serialNumber|manufacturer|udn}", validateWith = SearchCommandSortByValidator.class)

--- a/tools/org.jupnp.tool/src/main/java/org/jupnp/tool/cli/JUPnPTool.java
+++ b/tools/org.jupnp.tool/src/main/java/org/jupnp/tool/cli/JUPnPTool.java
@@ -191,23 +191,10 @@ public class JUPnPTool {
 		// sets the pool configuration
 		if (poolConfiguration != null) {
 			StringTokenizer tokenizer = new StringTokenizer(poolConfiguration, ",");
-			int core = Integer.valueOf(tokenizer.nextToken()).intValue();
-			int max = Integer.valueOf(tokenizer.nextToken()).intValue();
-			int queue = Integer.valueOf(tokenizer.nextToken()).intValue();
-			String timeoutAsString = tokenizer.nextToken().trim();
-			long timeout = 10000L; // in ms
-			if (timeoutAsString.endsWith("ms")) {
-				timeoutAsString = timeoutAsString.substring(0, timeoutAsString.indexOf("ms")).trim();
-				timeout = Integer.valueOf(timeoutAsString) * 1L;
-			} else if (timeoutAsString.endsWith("s")) {
-				timeoutAsString = timeoutAsString.substring(0, timeoutAsString.indexOf("s")).trim();
-				timeout = Integer.valueOf(timeoutAsString) * 1000L;
-			} else if (timeoutAsString.endsWith("m")) {
-				timeoutAsString = timeoutAsString.substring(0, timeoutAsString.indexOf("m")).trim();
-				timeout = Integer.valueOf(timeoutAsString) * 60L * 1000L;
-			}
+			int mainPoolSize = Integer.valueOf(tokenizer.nextToken()).intValue();
+			int asyncPoolSize = Integer.valueOf(tokenizer.nextToken()).intValue();
 
-			CmdlineUPnPServiceConfiguration.setPoolConfiguration(core, max, queue, timeout);
+			CmdlineUPnPServiceConfiguration.setPoolConfiguration(mainPoolSize, asyncPoolSize);
 			// one token left for stats option?
 			String stats = tokenizer.countTokens() == 1 ? tokenizer.nextToken() : null;
 			if (CommandLineArgs.POOL_CONFIG_STATS_OPTION.equalsIgnoreCase(stats)) {

--- a/tools/org.jupnp.tool/src/main/java/org/jupnp/tool/cli/MainCommandPoolConfigurationValidator.java
+++ b/tools/org.jupnp.tool/src/main/java/org/jupnp/tool/cli/MainCommandPoolConfigurationValidator.java
@@ -26,48 +26,23 @@ import com.beust.jcommander.ParameterException;
 public class MainCommandPoolConfigurationValidator implements IParameterValidator {
 
 	private final static String ERROR_MSG = "Paramer --pool must be of format "
-			+ "'<corePoolSize>,<maxPoolSize>,<queueSize>,<timeout>{ms|s|m}[,stats]'";
+			+ "'<mainPoolSize>,<asyncPoolSize>[,stats]'";
 
 	public void validate(String name, String value) throws ParameterException {
 		if (name.equals("--pool")) {
-			// pool config is sth like "20,40,1000,stats"
+			// pool config is sth like "20,20,stats"
 			StringTokenizer tokenizer = new StringTokenizer(value, ",");
-			// must have 3..4 args
-			if ((tokenizer.countTokens() < 4) || (tokenizer.countTokens() > 5)) {
-				throw new ParameterException(ERROR_MSG + " (not 4 or 5 parameters)");
+			// must have 2..3 args
+			if ((tokenizer.countTokens() < 2) || (tokenizer.countTokens() > 3)) {
+				throw new ParameterException(ERROR_MSG + " (not 2 or 3 parameters)");
 			} else {
 				try {
-					int corePoolSize = new Integer(tokenizer.nextToken()).intValue();
-					int maxPoolSize = new Integer(tokenizer.nextToken()).intValue();
-					int queueSize = new Integer(tokenizer.nextToken()).intValue();
-
-					String timeoutAsString = tokenizer.nextToken().trim();
-					long timeout = 10000L; // in ms
-					if (timeoutAsString.endsWith("ms")) {
-						String s = timeoutAsString.substring(0, timeoutAsString.indexOf("ms")).trim();
-						timeout = Integer.valueOf(s) * 1L;
-					} else if (timeoutAsString.endsWith("s")) {
-						String s = timeoutAsString.substring(0, timeoutAsString.indexOf("s")).trim();
-						timeout = Integer.valueOf(s) * 1000L;
-					} else if (timeoutAsString.endsWith("m")) {
-						String s = timeoutAsString.substring(0, timeoutAsString.indexOf("m")).trim();
-						timeout = Integer.valueOf(s) * 60L * 1000L;
-					} else {
-						// we assume ms as default
-						timeout = Integer.valueOf(timeoutAsString) * 1L;
-					}
+					int mainPoolSize = new Integer(tokenizer.nextToken()).intValue();
+					int asyncPoolSize = new Integer(tokenizer.nextToken()).intValue();
 
 					// all >0
-					if ((corePoolSize <= 0) || (maxPoolSize <= 0) || (queueSize <= 0)) {
+					if ((mainPoolSize <= 0) || (asyncPoolSize <= 0)) {
 						throw new ParameterException(ERROR_MSG + " (all values must be greater than 0)");
-					}
-					// core < max
-					if (corePoolSize > maxPoolSize) {
-						throw new ParameterException(ERROR_MSG + " (max must be greater than core)");
-					}
-					// timeout >0
-					if (timeout <= 0L) {
-						throw new ParameterException(ERROR_MSG + " (timeout must be greater than 0)");
 					}
 					// one token left?
 					if (tokenizer.countTokens() == 1) {

--- a/tools/org.jupnp.tool/src/main/java/org/jupnp/tool/cli/MonitoredQueueingThreadPoolExecutor.java
+++ b/tools/org.jupnp.tool/src/main/java/org/jupnp/tool/cli/MonitoredQueueingThreadPoolExecutor.java
@@ -1,0 +1,178 @@
+package org.jupnp.tool.cli;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.jupnp.QueueingThreadPoolExecutor;
+import org.jupnp.util.Exceptions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This class extends the {@link QueueingThreadPoolExecutor} about monitoring of
+ * tasks executed.
+ */
+public class MonitoredQueueingThreadPoolExecutor extends QueueingThreadPoolExecutor {
+
+	static boolean DEBUG_STATISTICS = false;
+
+	/** Statistical data collected. */
+	private MonitoredQueueingThreadPoolExecutor.Statistics stats;
+
+	static final transient Logger logger = LoggerFactory.getLogger(MonitoredQueueingThreadPoolExecutor.class);
+	static final transient Logger statsLogger = LoggerFactory.getLogger("org.jupnp.tool.cli.stats");
+
+	public MonitoredQueueingThreadPoolExecutor(String poolName, int threadPoolSize) {
+		super(poolName, threadPoolSize);
+		logger.debug("Created MonitoredQueueingThreadPoolExecutor with poolName=" + poolName + " and poolSize="
+				+ threadPoolSize);
+		if (DEBUG_STATISTICS) {
+			stats = new Statistics(poolName);
+		}
+	}
+
+	@Override
+	protected void beforeExecute(Thread t, Runnable r) {
+		if (DEBUG_STATISTICS) {
+			stats.addCurrentPoolSize(this);
+			stats.addExcecutor(r);
+		}
+		// TODO why so much executors?
+		// if (getQueue().size() > 100) {
+		// System.out.println("ALERT");
+		// }
+		super.beforeExecute(t, r);
+	}
+
+	@Override
+	protected void afterExecute(Runnable runnable, Throwable throwable) {
+		super.afterExecute(runnable, throwable);
+		if (throwable != null) {
+			Throwable cause = Exceptions.unwrap(throwable);
+			if ((cause instanceof InterruptedException) && isTerminating()) {
+				// Ignore this, might happen when we shutdownNow() the
+				// executor. We can't
+				// log at this point as the logging system might be stopped
+				// already (e.g. if it's a CDI component).
+				return;
+			}
+			// Log only
+			logger.warn("Thread terminated " + runnable + " abruptly with exception: " + throwable);
+			logger.warn("  Root cause: " + cause);
+		}
+	}
+
+	@Override
+	public void shutdown() {
+		logger.info("shutdown");
+		super.shutdown();
+		if (DEBUG_STATISTICS) {
+			stats.dumpPoolStats();
+			stats.dumpExecutorsStats();
+			stats.release();
+		}
+		logger.info("shutdown done");
+	}
+
+	@Override
+	public List<Runnable> shutdownNow() {
+		logger.info("shutdownNow");
+		List<Runnable> res = super.shutdownNow();
+		if (DEBUG_STATISTICS) {
+			stats.dumpPoolStats();
+			stats.dumpExecutorsStats();
+			stats.release();
+		}
+		logger.info("shutdownNow done");
+		return res;
+	}
+
+	// inner classes for statistics
+
+	static class Statistics {
+
+		static class PoolStatPoint {
+			public long timestamp, completedTasks;
+			public int corePoolSize, poolSize, maxPoolSize, activeCounts, queueSize;
+		}
+
+		/** Thread safe collection for points. */
+		private List<Statistics.PoolStatPoint> points = new CopyOnWriteArrayList<Statistics.PoolStatPoint>();
+
+		/** Thread safe collection for executors. */
+		private ConcurrentHashMap<String, AtomicInteger> executors = new ConcurrentHashMap<String, AtomicInteger>();
+
+		private final String poolName;
+
+		Statistics(String name) {
+			poolName = name;
+		}
+
+		/**
+		 * Add info about current pool status.
+		 */
+		private void addCurrentPoolSize(ThreadPoolExecutor pool) {
+			Statistics.PoolStatPoint p = new PoolStatPoint();
+			p.timestamp = System.currentTimeMillis();
+			p.corePoolSize = pool.getCorePoolSize();
+			p.poolSize = pool.getPoolSize();
+			p.maxPoolSize = pool.getMaximumPoolSize();
+			p.activeCounts = pool.getActiveCount();
+			p.queueSize = pool.getQueue().size();
+			p.completedTasks = pool.getCompletedTaskCount();
+			points.add(p);
+		}
+
+		/**
+		 * Increase number of calls to this runnable (by class name).
+		 */
+		public void addExcecutor(Runnable r) {
+			executors.putIfAbsent(r.getClass().getName(), new AtomicInteger(0));
+			executors.get(r.getClass().getName()).incrementAndGet();
+		}
+
+		public void release() {
+			points = null;
+			executors = null;
+		}
+
+		public void dumpPoolStats() {
+			statsLogger.info("Dump Pool Statistics for poolName: " + poolName);
+			statsLogger.info("[timestamp,corePoolSize,poolSize,maxPoolSize,activeThreads,queueSize,completedTasks]");
+			for (Iterator<Statistics.PoolStatPoint> iter = points.iterator(); iter.hasNext();) {
+				Statistics.PoolStatPoint p = iter.next();
+				statsLogger.info("" + p.timestamp + "," + p.corePoolSize + "," + p.poolSize + "," + p.maxPoolSize + ","
+						+ p.activeCounts + "," + p.queueSize + "," + p.completedTasks);
+			}
+			statsLogger.info(" ");
+		}
+
+		public void dumpExecutorsStats() {
+			statsLogger.info("Dump Pool Executors for poolName: " + poolName);
+
+			List<ConcurrentHashMap.Entry<String, AtomicInteger>> entries = new ArrayList<ConcurrentHashMap.Entry<String, AtomicInteger>>(
+					executors.entrySet());
+			// sort the entries by number of calls
+			Collections.sort(entries, new Comparator<ConcurrentHashMap.Entry<String, AtomicInteger>>() {
+				public int compare(ConcurrentHashMap.Entry<String, AtomicInteger> a,
+						ConcurrentHashMap.Entry<String, AtomicInteger> b) {
+					return Integer.compare(b.getValue().get(), a.getValue().get());
+				}
+			});
+
+			statsLogger.info("[executorClassName,numberOfExecutes]");
+			for (ConcurrentHashMap.Entry<String, AtomicInteger> e : entries) {
+				statsLogger.info(e.getKey() + "," + e.getValue().get());
+			}
+			statsLogger.info(" ");
+		}
+
+	}
+}

--- a/tools/org.jupnp.tool/src/main/java/org/jupnp/tool/cli/PrintUtils.java
+++ b/tools/org.jupnp.tool/src/main/java/org/jupnp/tool/cli/PrintUtils.java
@@ -42,8 +42,9 @@ public class PrintUtils {
 		for (Iterator<String[]> iter = table.iterator(); iter.hasNext();) {
 			String[] line = iter.next();
 			for (int i = 0; i < line.length; i++) {
-				maxColumnSizes[i] = Math.max(maxColumnSizes[i],
-						line[i].length());
+				if (line[i] != null) {
+					maxColumnSizes[i] = Math.max(maxColumnSizes[i], line[i].length());
+				}
 			}
 		}
 		// now print

--- a/tools/org.jupnp.tool/src/test/java/org/jupnp/tool/cli/CommandLineTest.java
+++ b/tools/org.jupnp.tool/src/test/java/org/jupnp/tool/cli/CommandLineTest.java
@@ -143,82 +143,42 @@ public class CommandLineTest extends AbstractTestCase {
 
 	@Test
 	public void testPoolConfigurationsOK() {
-		checkCommandLine(tool, JUPnPTool.RC_OK, "--pool=20,40,1000,10000ms nop");
-		Assert.assertThat(CmdlineUPnPServiceConfiguration.THREAD_CORE_POOL_SIZE, is(20));
-		Assert.assertThat(CmdlineUPnPServiceConfiguration.THREAD_MAX_POOL_SIZE, is(40));
-		Assert.assertThat(CmdlineUPnPServiceConfiguration.THREAD_QUEUE_SIZE, is(1000));
-		Assert.assertThat(CmdlineUPnPServiceConfiguration.TIMEOUT_MILLI_SECONDS, is(10000L));
-		Assert.assertThat(CmdlineUPnPServiceConfiguration.DEBUG_STATISTICS, is(false));
-
-		checkCommandLine(tool, JUPnPTool.RC_OK, "--pool=20,40,1000,10s nop");
-		Assert.assertThat(CmdlineUPnPServiceConfiguration.TIMEOUT_MILLI_SECONDS, is(10000L));
-
-		checkCommandLine(tool, JUPnPTool.RC_OK, "--pool=20,40,1000,1m nop");
-		Assert.assertThat(CmdlineUPnPServiceConfiguration.TIMEOUT_MILLI_SECONDS, is(60L * 1000L));
-
-		checkCommandLine(tool, JUPnPTool.RC_OK, "-p=20,40,1000,1000ms nop");
-		Assert.assertThat(CmdlineUPnPServiceConfiguration.TIMEOUT_MILLI_SECONDS, is(1000L));
-
-		checkCommandLine(tool, JUPnPTool.RC_OK, "-p=20,20,1000,100ms nop");
-		Assert.assertThat(CmdlineUPnPServiceConfiguration.TIMEOUT_MILLI_SECONDS, is(100L));
-
-		checkCommandLine(tool, JUPnPTool.RC_OK, "-p=1,1,1,10ms nop");
-		Assert.assertThat(CmdlineUPnPServiceConfiguration.TIMEOUT_MILLI_SECONDS, is(10L));
-
-		checkCommandLine(tool, JUPnPTool.RC_OK, "--pool=20,40,1000,1ms,stats nop");
-		Assert.assertThat(CmdlineUPnPServiceConfiguration.TIMEOUT_MILLI_SECONDS, is(1L));
-
-		checkCommandLine(tool, JUPnPTool.RC_OK, "--pool=20,40,1000,10ms nop");
-		Assert.assertThat(CmdlineUPnPServiceConfiguration.TIMEOUT_MILLI_SECONDS, is(10L));
+		CmdlineUPnPServiceConfiguration.setDebugStatistics(false);
+		checkCommandLine(tool, JUPnPTool.RC_OK, "--pool=20,20 nop");
+		Assert.assertThat(CmdlineUPnPServiceConfiguration.MAIN_POOL_SIZE, is(20));
+		Assert.assertThat(CmdlineUPnPServiceConfiguration.ASYNC_POOL_SIZE, is(20));
+		Assert.assertThat(MonitoredQueueingThreadPoolExecutor.DEBUG_STATISTICS, is(false));
 	}
 
 	@Test
 	public void testPoolConfigurationsWrong() {
-		checkCommandLine(tool, JUPnPTool.RC_INVALID_OPTION, "--pool=20,40,1000 nop");
-		Assert.assertThat(err.toString(), containsString("(not 4 or 5 parameters)"));
-		resetStreams();
-
-		checkCommandLine(tool, JUPnPTool.RC_INVALID_OPTION, "--pool=20,40,1000 nop");
-		Assert.assertThat(err.toString(), containsString("(not 4 or 5 parameters)"));
+		checkCommandLine(tool, JUPnPTool.RC_INVALID_OPTION, "--pool=20,20,20,20 nop");
+		Assert.assertThat(err.toString(), containsString("(not 2 or 3 parameters)"));
 		resetStreams();
 
 		checkCommandLine(tool, JUPnPTool.RC_INVALID_OPTION, "--pool=20 nop");
-		Assert.assertThat(err.toString(), containsString("(not 4 or 5 parameters)"));
+		Assert.assertThat(err.toString(), containsString("(not 2 or 3 parameters)"));
 		resetStreams();
 
-		checkCommandLine(tool, JUPnPTool.RC_INVALID_OPTION, "-p=20,40 nop");
-		Assert.assertThat(err.toString(), containsString("(not 4 or 5 parameters)"));
-		resetStreams();
-
-		checkCommandLine(tool, JUPnPTool.RC_INVALID_OPTION, "-p=40,20,1000,10000ms nop");
-		Assert.assertThat(err.toString(), containsString("(max must be greater than core)"));
-		resetStreams();
-
-		checkCommandLine(tool, JUPnPTool.RC_INVALID_OPTION, "-p=0,0,0,10000ms nop");
+		checkCommandLine(tool, JUPnPTool.RC_INVALID_OPTION, "-p=0,0 nop");
 		Assert.assertThat(err.toString(), containsString("(all values must be greater than 0)"));
 		resetStreams();
 
-		checkCommandLine(tool, JUPnPTool.RC_INVALID_OPTION, "-p=-1,40,1000,10000ms nop");
+		checkCommandLine(tool, JUPnPTool.RC_INVALID_OPTION, "-p=-1,20 nop");
 		Assert.assertThat(err.toString(), containsString("(all values must be greater than 0)"));
 		resetStreams();
-		checkCommandLine(tool, JUPnPTool.RC_INVALID_OPTION, "-p=20,-1,1000,10000ms nop");
-		Assert.assertThat(err.toString(), containsString("(all values must be greater than 0)"));
-		resetStreams();
-		checkCommandLine(tool, JUPnPTool.RC_INVALID_OPTION, "-p=20,40,-1,10000ms nop");
+		checkCommandLine(tool, JUPnPTool.RC_INVALID_OPTION, "-p=20,-1 nop");
 		Assert.assertThat(err.toString(), containsString("(all values must be greater than 0)"));
 		resetStreams();
 
-		checkCommandLine(tool, JUPnPTool.RC_INVALID_OPTION, "--pool=20A,40,1000,10000ms nop");
+		checkCommandLine(tool, JUPnPTool.RC_INVALID_OPTION, "--pool=20A,40 nop");
 		Assert.assertThat(err.toString(), containsString("(numbers wrong)"));
 		resetStreams();
-		checkCommandLine(tool, JUPnPTool.RC_INVALID_OPTION, "--pool=20,4B0,1000,10000ms nop");
-		Assert.assertThat(err.toString(), containsString("(numbers wrong)"));
-		resetStreams();
-		checkCommandLine(tool, JUPnPTool.RC_INVALID_OPTION, "--pool=20,40,C1000,10000ms nop");
+		checkCommandLine(tool, JUPnPTool.RC_INVALID_OPTION, "--pool=20,4B0 nop");
 		Assert.assertThat(err.toString(), containsString("(numbers wrong)"));
 		resetStreams();
 
-		checkCommandLine(tool, JUPnPTool.RC_INVALID_OPTION, "--pool=20,40,1000,10000ms,WRONGOPTIONS nop");
+		checkCommandLine(tool, JUPnPTool.RC_INVALID_OPTION, "--pool=20,40,WRONGOPTIONS nop");
 		Assert.assertThat(err.toString(), containsString("(only stats allowed as last option)"));
 		resetStreams();
 	}

--- a/tools/org.jupnp.tool/src/test/java/org/jupnp/tool/cli/SearchCommandTest.java
+++ b/tools/org.jupnp.tool/src/test/java/org/jupnp/tool/cli/SearchCommandTest.java
@@ -75,6 +75,11 @@ public class SearchCommandTest extends AbstractTestCase {
 	}
 
 	@Test
+	public void testSearchNoSortWithStatistics() {
+		checkCommandLine(tool, JUPnPTool.RC_OK, "--pool=20,40,stats search");
+	}
+
+	@Test
 	public void testSearchSortByIp() {
 		// checkCommandLine(tool, JUPnPTool.RC_OK, "--loglevel=INFO search");
 		checkCommandLine(tool, JUPnPTool.RC_OK, "search --timeout=20 --sort=ip");


### PR DESCRIPTION
* extended QueueingThreadPoolExecutor to allow subclassing
* added a MonitoredQueueingThreadPoolExecutor
* introduced like for OSGi main/async executors
* changed cmdline args to configure main/async pools

Signed-off-by: Jochen Hiller <jo.hiller@googlemail.com>
