### PR TITLE
Fixed deadlocks due to excessive locking in GENASubscription and Regi…

### DIFF
--- a/bundles/org.jupnp/src/main/java/org/jupnp/model/ExpirationDetails.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/model/ExpirationDetails.java
@@ -25,6 +25,8 @@ public class ExpirationDetails {
 
     private int maxAgeSeconds = UNLIMITED_AGE;
     private long lastRefreshTimestampSeconds = getCurrentTimestampSeconds();
+    
+    private int renewAttempts;
 
     public ExpirationDetails() {
     }
@@ -51,6 +53,14 @@ public class ExpirationDetails {
 
     public boolean hasExpired() {
         return hasExpired(false);
+    }
+    
+    public void renewAttempted() {
+        renewAttempts++;
+    }
+    
+    public int getRenewAttempts() {
+        return renewAttempts;
     }
 
     /**

--- a/bundles/org.jupnp/src/main/java/org/jupnp/model/gena/GENASubscription.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/model/gena/GENASubscription.java
@@ -14,8 +14,8 @@
 
 package org.jupnp.model.gena;
 
-import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.jupnp.model.UserConstants;
 import org.jupnp.model.meta.Service;
@@ -34,12 +34,12 @@ import org.jupnp.model.types.UnsignedIntegerFourBytes;
  */
 public abstract class GENASubscription<S extends Service> {
 
-    protected S service;
-    protected String subscriptionId;
-    protected int requestedDurationSeconds = UserConstants.DEFAULT_SUBSCRIPTION_DURATION_SECONDS;
-    protected int actualDurationSeconds;
-    protected UnsignedIntegerFourBytes currentSequence;
-    protected Map<String, StateVariableValue<S>> currentValues = new LinkedHashMap();
+    protected final S service;
+    protected volatile String subscriptionId;
+    protected volatile int requestedDurationSeconds = UserConstants.DEFAULT_SUBSCRIPTION_DURATION_SECONDS;
+    protected volatile int actualDurationSeconds;
+    protected volatile UnsignedIntegerFourBytes currentSequence;
+    protected Map<String, StateVariableValue<S>> currentValues = new ConcurrentHashMap();
 
     /**
      * Defaults to {@link org.jupnp.model.UserConstants#DEFAULT_SUBSCRIPTION_DURATION_SECONDS}.
@@ -53,35 +53,35 @@ public abstract class GENASubscription<S extends Service> {
         this.requestedDurationSeconds = requestedDurationSeconds;
     }
 
-    synchronized public S getService() {
+    public S getService() {
         return service;
     }
 
-    synchronized public String getSubscriptionId() {
+    public String getSubscriptionId() {
         return subscriptionId;
     }
 
-    synchronized public void setSubscriptionId(String subscriptionId) {
+    public void setSubscriptionId(String subscriptionId) {
         this.subscriptionId = subscriptionId;
     }
 
-    synchronized public int getRequestedDurationSeconds() {
+    public int getRequestedDurationSeconds() {
         return requestedDurationSeconds;
     }
 
-    synchronized public int getActualDurationSeconds() {
+    public int getActualDurationSeconds() {
         return actualDurationSeconds;
     }
 
-    synchronized public void setActualSubscriptionDurationSeconds(int seconds) {
+    public void setActualSubscriptionDurationSeconds(int seconds) {
         this.actualDurationSeconds = seconds;
     }
 
-    synchronized public UnsignedIntegerFourBytes getCurrentSequence() {
+    public UnsignedIntegerFourBytes getCurrentSequence() {
         return currentSequence;
     }
 
-    synchronized public Map<String, StateVariableValue<S>> getCurrentValues() {
+    public Map<String, StateVariableValue<S>> getCurrentValues() {
         return currentValues;
     }
 

--- a/bundles/org.jupnp/src/main/java/org/jupnp/registry/RegistryImpl.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/registry/RegistryImpl.java
@@ -55,6 +55,7 @@ public class RegistryImpl implements Registry {
     protected UpnpService upnpService;
     protected RegistryMaintainer registryMaintainer;
     protected final Set<RemoteGENASubscription> pendingSubscriptionsLock = new HashSet();
+    protected Object lock = new Object();
 
     public RegistryImpl() {
     }
@@ -104,24 +105,31 @@ public class RegistryImpl implements Registry {
 
     // #################################################################################################
 
-    synchronized public void addListener(RegistryListener listener) {
-        registryListeners.add(listener);
+    public void addListener(RegistryListener listener) {
+        synchronized(registryListeners) {
+            registryListeners.add(listener);
+        }
     }
 
-    synchronized public void removeListener(RegistryListener listener) {
-        registryListeners.remove(listener);
+    public void removeListener(RegistryListener listener) {
+        synchronized(registryListeners) {
+            registryListeners.remove(listener);
+        }
     }
 
-    synchronized public Collection<RegistryListener> getListeners() {
-        return Collections.unmodifiableCollection(registryListeners);
+    public Collection<RegistryListener> getListeners() {
+        synchronized(registryListeners) {
+            return Collections.unmodifiableCollection(registryListeners);
+        }
     }
 
-    synchronized public boolean notifyDiscoveryStart(final RemoteDevice device) {
+    public boolean notifyDiscoveryStart(final RemoteDevice device) {
         // Exit if we have it already, this is atomic inside this method, finally
         if (getUpnpService().getRegistry().getRemoteDevice(device.getIdentity().getUdn(), true) != null) {
             log.finer("Not notifying listeners, already registered: " + device);
             return false;
         }
+        
         for (final RegistryListener listener : getListeners()) {
             getConfiguration().getRegistryListenerExecutor().execute(
                     new Runnable() {
@@ -131,10 +139,11 @@ public class RegistryImpl implements Registry {
                     }
             );
         }
+        
         return true;
     }
 
-    synchronized public void notifyDiscoveryFailure(final RemoteDevice device, final Exception ex) {
+    public void notifyDiscoveryFailure(final RemoteDevice device, final Exception ex) {
         for (final RegistryListener listener : getListeners()) {
             getConfiguration().getRegistryListenerExecutor().execute(
                     new Runnable() {
@@ -148,47 +157,67 @@ public class RegistryImpl implements Registry {
 
     // #################################################################################################
 
-    synchronized public void addDevice(LocalDevice localDevice) {
-        localItems.add(localDevice);
+    public void addDevice(LocalDevice localDevice) {
+        synchronized(localItems) {
+            localItems.add(localDevice);
+        }
     }
 
-    synchronized public void addDevice(LocalDevice localDevice, DiscoveryOptions options) {
-        localItems.add(localDevice, options);
+    public void addDevice(LocalDevice localDevice, DiscoveryOptions options) {
+        synchronized(localItems) {
+            localItems.add(localDevice, options);
+        }
     }
 
-    synchronized public void setDiscoveryOptions(UDN udn, DiscoveryOptions options) {
-        localItems.setDiscoveryOptions(udn, options);
+    public void setDiscoveryOptions(UDN udn, DiscoveryOptions options) {
+        synchronized(localItems) {
+            localItems.setDiscoveryOptions(udn, options);
+        }
     }
 
-    synchronized public DiscoveryOptions getDiscoveryOptions(UDN udn) {
-        return localItems.getDiscoveryOptions(udn);
+    public DiscoveryOptions getDiscoveryOptions(UDN udn) {
+        synchronized(localItems) {
+            return localItems.getDiscoveryOptions(udn);
+        }
     }
 
-    synchronized public void addDevice(RemoteDevice remoteDevice) {
-        remoteItems.add(remoteDevice);
+    public void addDevice(RemoteDevice remoteDevice) {
+        synchronized(remoteItems) {
+            remoteItems.add(remoteDevice);
+        }
     }
 
-    synchronized public boolean update(RemoteDeviceIdentity rdIdentity) {
-        return remoteItems.update(rdIdentity);
+    public boolean update(RemoteDeviceIdentity rdIdentity) {
+        synchronized(remoteItems) {
+            return remoteItems.update(rdIdentity);
+        }
     }
 
-    synchronized public boolean removeDevice(LocalDevice localDevice) {
-        return localItems.remove(localDevice);
+    public boolean removeDevice(LocalDevice localDevice) {
+        synchronized(localItems) {
+            return localItems.remove(localDevice);
+        }
     }
 
-    synchronized public boolean removeDevice(RemoteDevice remoteDevice) {
-        return remoteItems.remove(remoteDevice);
+    public boolean removeDevice(RemoteDevice remoteDevice) {
+        synchronized(remoteItems) {
+            return remoteItems.remove(remoteDevice);
+        }
     }
 
-    synchronized public void removeAllLocalDevices() {
-        localItems.removeAll();
+    public void removeAllLocalDevices() {
+        synchronized(localItems) {
+            localItems.removeAll();
+        }
     }
 
-    synchronized public void removeAllRemoteDevices() {
-        remoteItems.removeAll();
+    public void removeAllRemoteDevices() {
+        synchronized(remoteItems) {
+            remoteItems.removeAll();
+        }
     }
 
-    synchronized public boolean removeDevice(UDN udn) {
+    public boolean removeDevice(UDN udn) {
         Device device = getDevice(udn, true);
         if (device != null && device instanceof LocalDevice)
             return removeDevice((LocalDevice) device);
@@ -197,55 +226,84 @@ public class RegistryImpl implements Registry {
         return false;
     }
 
-    synchronized public Device getDevice(UDN udn, boolean rootOnly) {
+    public Device getDevice(UDN udn, boolean rootOnly) {
         Device device;
-        if ((device = localItems.get(udn, rootOnly)) != null) return device;
-        if ((device = remoteItems.get(udn, rootOnly)) != null) return device;
+        synchronized(localItems) {
+            if ((device = localItems.get(udn, rootOnly)) != null) return device;
+        }
+        synchronized(remoteItems) {
+            if ((device = remoteItems.get(udn, rootOnly)) != null) return device;
+        }
+        
         return null;
     }
 
-    synchronized public LocalDevice getLocalDevice(UDN udn, boolean rootOnly) {
-        return localItems.get(udn, rootOnly);
+    public LocalDevice getLocalDevice(UDN udn, boolean rootOnly) {
+        synchronized(localItems) {
+            return localItems.get(udn, rootOnly);
+        }
     }
 
-    synchronized public RemoteDevice getRemoteDevice(UDN udn, boolean rootOnly) {
-        return remoteItems.get(udn, rootOnly);
+    public RemoteDevice getRemoteDevice(UDN udn, boolean rootOnly) {
+        synchronized(remoteItems) {
+            return remoteItems.get(udn, rootOnly);
+        }
     }
 
-    synchronized public Collection<LocalDevice> getLocalDevices() {
-        return Collections.unmodifiableCollection(localItems.get());
+    public Collection<LocalDevice> getLocalDevices() {
+        synchronized(localItems) {
+            return Collections.unmodifiableCollection(localItems.get());
+        }
     }
 
-    synchronized public Collection<RemoteDevice> getRemoteDevices() {
-        return Collections.unmodifiableCollection(remoteItems.get());
+    public Collection<RemoteDevice> getRemoteDevices() {
+        synchronized(remoteItems) {
+            return Collections.unmodifiableCollection(remoteItems.get());
+        }
     }
 
-    synchronized public Collection<Device> getDevices() {
+    public Collection<Device> getDevices() {
         Set all = new HashSet();
-        all.addAll(localItems.get());
-        all.addAll(remoteItems.get());
+        synchronized(localItems) {
+            all.addAll(localItems.get());
+        }
+        
+        synchronized(remoteItems) {
+            all.addAll(remoteItems.get());
+        }
+        
         return Collections.unmodifiableCollection(all);
     }
 
-    synchronized public Collection<Device> getDevices(DeviceType deviceType) {
+    public Collection<Device> getDevices(DeviceType deviceType) {
         Collection<Device> devices = new HashSet();
 
-        devices.addAll(localItems.get(deviceType));
-        devices.addAll(remoteItems.get(deviceType));
+        synchronized(localItems) {
+            devices.addAll(localItems.get(deviceType));
+        }
+        
+        synchronized(remoteItems) {
+            devices.addAll(remoteItems.get(deviceType));
+        }
 
         return Collections.unmodifiableCollection(devices);
     }
 
-    synchronized public Collection<Device> getDevices(ServiceType serviceType) {
+    public Collection<Device> getDevices(ServiceType serviceType) {
         Collection<Device> devices = new HashSet();
 
-        devices.addAll(localItems.get(serviceType));
-        devices.addAll(remoteItems.get(serviceType));
+        synchronized(localItems) {
+            devices.addAll(localItems.get(serviceType));
+        }
+        
+        synchronized(remoteItems) {
+            devices.addAll(remoteItems.get(serviceType));
+        }
 
         return Collections.unmodifiableCollection(devices);
     }
 
-    synchronized public Service getService(ServiceReference serviceReference) {
+    public Service getService(ServiceReference serviceReference) {
         Device device;
         if ((device = getDevice(serviceReference.getUdn(), false)) != null) {
             return device.findService(serviceReference.getServiceId());
@@ -255,29 +313,33 @@ public class RegistryImpl implements Registry {
 
     // #################################################################################################
 
-    synchronized public Resource getResource(URI pathQuery) throws IllegalArgumentException {
+    public Resource getResource(URI pathQuery) throws IllegalArgumentException {
         if (pathQuery.isAbsolute()) {
             throw new IllegalArgumentException("Resource URI can not be absolute, only path and query:" + pathQuery);
         }
 
         // Note: Uses field access on resourceItems for performance reasons
 
-		for (RegistryItem<URI, Resource> resourceItem : resourceItems) {
-        	Resource resource = resourceItem.getItem();
-        	if (resource.matches(pathQuery)) {
-                return resource;
+        synchronized(resourceItems) {
+    		for (RegistryItem<URI, Resource> resourceItem : resourceItems) {
+            	Resource resource = resourceItem.getItem();
+            	if (resource.matches(pathQuery)) {
+                    return resource;
+                }
             }
         }
 
         // TODO: UPNP VIOLATION: Fuppes on my ReadyNAS thinks it's a cool idea to add a slash at the end of the callback URI...
         // It also cuts off any query parameters in the callback URL - nice!
-        if (pathQuery.getPath().endsWith("/")) {
-            URI pathQueryWithoutSlash = URI.create(pathQuery.toString().substring(0, pathQuery.toString().length() - 1));
-
- 			for (RegistryItem<URI, Resource> resourceItem : resourceItems) {
-            	Resource resource = resourceItem.getItem();
-            	if (resource.matches(pathQueryWithoutSlash)) {
-                    return resource;
+        synchronized(resourceItems) {
+            if (pathQuery.getPath().endsWith("/")) {
+                URI pathQueryWithoutSlash = URI.create(pathQuery.toString().substring(0, pathQuery.toString().length() - 1));
+    
+     			for (RegistryItem<URI, Resource> resourceItem : resourceItems) {
+                	Resource resource = resourceItem.getItem();
+                	if (resource.matches(pathQueryWithoutSlash)) {
+                        return resource;
+                    }
                 }
             }
         }
@@ -285,7 +347,7 @@ public class RegistryImpl implements Registry {
         return null;
     }
 
-    synchronized public <T extends Resource> T getResource(Class<T> resourceType, URI pathQuery) throws IllegalArgumentException {
+    public <T extends Resource> T getResource(Class<T> resourceType, URI pathQuery) throws IllegalArgumentException {
         Resource resource = getResource(pathQuery);
         if (resource != null && resourceType.isAssignableFrom(resource.getClass())) {
             return (T) resource;
@@ -293,181 +355,248 @@ public class RegistryImpl implements Registry {
         return null;
     }
 
-    synchronized public Collection<Resource> getResources() {
+    public Collection<Resource> getResources() {
         Collection<Resource> s = new HashSet();
-        for (RegistryItem<URI, Resource> resourceItem : resourceItems) {
-            s.add(resourceItem.getItem());
+        synchronized(resourceItems) {
+            for (RegistryItem<URI, Resource> resourceItem : resourceItems) {
+                s.add(resourceItem.getItem());
+            }
         }
         return s;
     }
 
-    synchronized public <T extends Resource> Collection<T> getResources(Class<T> resourceType) {
+    public <T extends Resource> Collection<T> getResources(Class<T> resourceType) {
         Collection<T> s = new HashSet();
-        for (RegistryItem<URI, Resource> resourceItem : resourceItems) {
-            if (resourceType.isAssignableFrom(resourceItem.getItem().getClass()))
-                s.add((T) resourceItem.getItem());
+        synchronized(resourceItems) {
+            for (RegistryItem<URI, Resource> resourceItem : resourceItems) {
+                if (resourceType.isAssignableFrom(resourceItem.getItem().getClass()))
+                    s.add((T) resourceItem.getItem());
+            }
         }
         return s;
     }
 
-    synchronized public void addResource(Resource resource) {
+    public void addResource(Resource resource) {
         addResource(resource, ExpirationDetails.UNLIMITED_AGE);
     }
 
-    synchronized public void addResource(Resource resource, int maxAgeSeconds) {
+    public void addResource(Resource resource, int maxAgeSeconds) {
         RegistryItem resourceItem = new RegistryItem(resource.getPathQuery(), resource, maxAgeSeconds);
-        resourceItems.remove(resourceItem);
-        resourceItems.add(resourceItem);
+        synchronized(resourceItems) {
+            resourceItems.remove(resourceItem);
+            resourceItems.add(resourceItem);
+        }
     }
 
-    synchronized public boolean removeResource(Resource resource) {
-        return resourceItems.remove(new RegistryItem(resource.getPathQuery()));
+    public boolean removeResource(Resource resource) {
+        synchronized(resourceItems) {
+            return resourceItems.remove(new RegistryItem(resource.getPathQuery()));
+        }
     }
 
     // #################################################################################################
 
-    synchronized public void addLocalSubscription(LocalGENASubscription subscription) {
-        localItems.addSubscription(subscription);
+    public void addLocalSubscription(LocalGENASubscription subscription) {
+        synchronized(localItems) {
+            localItems.addSubscription(subscription);
+        }
     }
 
-    synchronized public LocalGENASubscription getLocalSubscription(String subscriptionId) {
-        return localItems.getSubscription(subscriptionId);
+    public LocalGENASubscription getLocalSubscription(String subscriptionId) {
+        synchronized(localItems) {
+            return localItems.getSubscription(subscriptionId);
+        }
     }
 
-    synchronized public boolean updateLocalSubscription(LocalGENASubscription subscription) {
-        return localItems.updateSubscription(subscription);
+    public boolean updateLocalSubscription(LocalGENASubscription subscription) {
+        synchronized(localItems) {
+            return localItems.updateSubscription(subscription);
+        }
     }
 
-    synchronized public boolean removeLocalSubscription(LocalGENASubscription subscription) {
-        return localItems.removeSubscription(subscription);
+    public boolean removeLocalSubscription(LocalGENASubscription subscription) {
+        synchronized(localItems) {
+            return localItems.removeSubscription(subscription);
+        }
     }
 
-    synchronized public void addRemoteSubscription(RemoteGENASubscription subscription) {
-        remoteItems.addSubscription(subscription);
+    public void addRemoteSubscription(RemoteGENASubscription subscription) {
+        synchronized(remoteItems) {
+            remoteItems.addSubscription(subscription);
+        }
     }
 
-    synchronized public RemoteGENASubscription getRemoteSubscription(String subscriptionId) {
-        return remoteItems.getSubscription(subscriptionId);
+    public RemoteGENASubscription getRemoteSubscription(String subscriptionId) {
+        synchronized(remoteItems) {
+            return remoteItems.getSubscription(subscriptionId);
+        }
     }
 
-    synchronized public void updateRemoteSubscription(RemoteGENASubscription subscription) {
-        remoteItems.updateSubscription(subscription);
+    public void updateRemoteSubscription(RemoteGENASubscription subscription) {
+        synchronized(remoteItems) {
+            remoteItems.updateSubscription(subscription);
+        }
     }
 
-    synchronized public void removeRemoteSubscription(RemoteGENASubscription subscription) {
-        remoteItems.removeSubscription(subscription);
+    public void removeRemoteSubscription(RemoteGENASubscription subscription) {
+        synchronized(remoteItems) {
+            remoteItems.removeSubscription(subscription);
+        }
     }
 
     /* ############################################################################################################ */
 
-   	synchronized public void advertiseLocalDevices() {
-   		localItems.advertiseLocalDevices();
+   	public void advertiseLocalDevices() {
+       	 synchronized(localItems) {
+       		localItems.advertiseLocalDevices();
+       	 }
    	}
 
     /* ############################################################################################################ */
 
     // When you call this, make sure you have the Router lock before this lock is obtained!
-    synchronized public void shutdown() {
+    public void shutdown() {
         log.fine("Shutting down registry...");
 
-        if (registryMaintainer != null)
-            registryMaintainer.stop();
+        synchronized(lock) {
+            if (registryMaintainer != null)
+                registryMaintainer.stop();
+        }
         
         // Final cleanup run to flush out pending executions which might
         // not have been caught by the maintainer before it stopped
-        log.finest("Executing final pending operations on shutdown: " + pendingExecutions.size());
-        runPendingExecutions(false);
-
-        for (RegistryListener listener : registryListeners) {
-            listener.beforeShutdown(this);
+        synchronized(pendingExecutions) {
+            log.finest("Executing final pending operations on shutdown: " + pendingExecutions.size());
+            runPendingExecutions(false);
         }
 
-        RegistryItem<URI, Resource>[] resources = resourceItems.toArray(new RegistryItem[resourceItems.size()]);
-        for (RegistryItem<URI, Resource> resourceItem : resources) {
-            resourceItem.getItem().shutdown();
+        synchronized(registryListeners) {
+            for (RegistryListener listener : registryListeners) {
+                listener.beforeShutdown(this);
+            }
         }
 
-        remoteItems.shutdown();
-        localItems.shutdown();
-
-        for (RegistryListener listener : registryListeners) {
-            listener.afterShutdown();
+        synchronized(resourceItems) {
+            RegistryItem<URI, Resource>[] resources = resourceItems.toArray(new RegistryItem[resourceItems.size()]);
+            for (RegistryItem<URI, Resource> resourceItem : resources) {
+                resourceItem.getItem().shutdown();
+            }
         }
-    }
 
-    synchronized public void pause() {
-        if (registryMaintainer != null) {
-            log.fine("Pausing registry maintenance");
-            runPendingExecutions(true);
-            registryMaintainer.stop();
-            registryMaintainer = null;
+        
+        synchronized(remoteItems) {
+            remoteItems.shutdown();
         }
-    }
+        
+        synchronized(localItems) {
+            localItems.shutdown();
+        }
 
-    synchronized public void resume() {
-        if (registryMaintainer == null) {
-            log.fine("Resuming registry maintenance");
-            remoteItems.resume();
-            registryMaintainer = createRegistryMaintainer();
-            if (registryMaintainer != null) {
-                getConfiguration().getRegistryMaintainerExecutor().execute(registryMaintainer);
+        synchronized(registryListeners) {
+            for (RegistryListener listener : registryListeners) {
+                listener.afterShutdown();
             }
         }
     }
 
-    synchronized public boolean isPaused() {
-        return registryMaintainer == null;
+    public void pause() {
+        synchronized(lock) {
+            if (registryMaintainer != null) {
+                log.fine("Pausing registry maintenance");
+                runPendingExecutions(true);
+                registryMaintainer.stop();
+                registryMaintainer = null;
+            }
+        }
+    }
+
+    public void resume() {
+        synchronized(lock) {
+            if (registryMaintainer == null) {
+                log.fine("Resuming registry maintenance");
+                synchronized(remoteItems) {
+                    remoteItems.resume();
+                }
+                
+                registryMaintainer = createRegistryMaintainer();
+                if (registryMaintainer != null) {
+                    getConfiguration().getRegistryMaintainerExecutor().execute(registryMaintainer);
+                }
+            }
+        }
+    }
+
+    public boolean isPaused() {
+        synchronized(lock) {
+            return registryMaintainer == null;
+        }
     }
 
     /* ############################################################################################################ */
 
-    synchronized void maintain() {
+    void maintain() {
 
         if (log.isLoggable(Level.FINEST))
             log.finest("Maintaining registry...");
 
         // Remove expired resources
-        Iterator<RegistryItem<URI, Resource>> it = resourceItems.iterator();
-        while (it.hasNext()) {
-            RegistryItem<URI, Resource> item = it.next();
-            if (item.getExpirationDetails().hasExpired()) {
-                if (log.isLoggable(Level.FINER))
-                    log.finer("Removing expired resource: " + item);
-                it.remove();
+        synchronized (resourceItems) {
+            Iterator<RegistryItem<URI, Resource>> it = resourceItems.iterator();
+            while (it.hasNext()) {
+                RegistryItem<URI, Resource> item = it.next();
+                if (item.getExpirationDetails().hasExpired()) {
+                    if (log.isLoggable(Level.FINER))
+                        log.finer("Removing expired resource: " + item);
+                    it.remove();
+                }
+            }
+            
+            // Let each resource do its own maintenance
+            synchronized(pendingExecutions) {
+                for (RegistryItem<URI, Resource> resourceItem : resourceItems) {
+                    resourceItem.getItem().maintain(
+                            pendingExecutions,
+                            resourceItem.getExpirationDetails()
+                    );
+                }
             }
         }
 
-        // Let each resource do its own maintenance
-        for (RegistryItem<URI, Resource> resourceItem : resourceItems) {
-            resourceItem.getItem().maintain(
-                    pendingExecutions,
-                    resourceItem.getExpirationDetails()
-            );
-        }
+
+
 
         // These add all their operations to the pendingExecutions queue
-        remoteItems.maintain();
-        localItems.maintain();
+        synchronized(remoteItems) {
+            remoteItems.maintain();
+        }
+        
+        synchronized (localItems) {
+            localItems.maintain();
+        }
 
         // We now run the queue asynchronously so the maintenance thread can continue its loop undisturbed
         runPendingExecutions(true);
     }
 
-    synchronized void executeAsyncProtocol(Runnable runnable) {
-        pendingExecutions.add(runnable);
+    void executeAsyncProtocol(Runnable runnable) {
+        synchronized (pendingExecutions) {
+            pendingExecutions.add(runnable);
+        }
     }
 
-    synchronized void runPendingExecutions(boolean async) {
-        if (log.isLoggable(Level.FINEST))
-            log.finest("Executing pending operations: " + pendingExecutions.size());
-        for (Runnable pendingExecution : pendingExecutions) {
-            if (async)
-                getConfiguration().getAsyncProtocolExecutor().execute(pendingExecution);
-            else
-                pendingExecution.run();
-        }
-        if (pendingExecutions.size() > 0) {
-            pendingExecutions.clear();
+    void runPendingExecutions(boolean async) {
+        synchronized (pendingExecutions) {
+            if (log.isLoggable(Level.FINEST))
+                log.finest("Executing pending operations: " + pendingExecutions.size());
+            for (Runnable pendingExecution : pendingExecutions) {
+                if (async)
+                    getConfiguration().getAsyncProtocolExecutor().execute(pendingExecution);
+                else
+                    pendingExecution.run();
+            }
+            if (pendingExecutions.size() > 0) {
+                pendingExecutions.clear();
+            }
         }
     }
 
@@ -477,20 +606,26 @@ public class RegistryImpl implements Registry {
         if (log.isLoggable(Level.FINE)) {
             log.fine("====================================    REMOTE   ================================================");
 
-            for (RemoteDevice remoteDevice : remoteItems.get()) {
-                log.fine(remoteDevice.toString());
+            synchronized(remoteItems) {
+                for (RemoteDevice remoteDevice : remoteItems.get()) {
+                    log.fine(remoteDevice.toString());
+                }
             }
 
             log.fine("====================================    LOCAL    ================================================");
 
-            for (LocalDevice localDevice : localItems.get()) {
-                log.fine(localDevice.toString());
+            synchronized(localItems) {
+                for (LocalDevice localDevice : localItems.get()) {
+                    log.fine(localDevice.toString());
+                }
             }
 
             log.fine("====================================  RESOURCES  ================================================");
 
-            for (RegistryItem<URI, Resource> resourceItem : resourceItems) {
-                log.fine(resourceItem.toString());
+            synchronized(resourceItems) {
+                for (RegistryItem<URI, Resource> resourceItem : resourceItems) {
+                    log.fine(resourceItem.toString());
+                }
             }
 
             log.fine("=================================================================================================");

--- a/bundles/org.jupnp/src/main/java/org/jupnp/registry/RemoteItems.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/registry/RemoteItems.java
@@ -25,6 +25,7 @@ import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import org.jupnp.model.ExpirationDetails;
 import org.jupnp.model.gena.CancelReason;
 import org.jupnp.model.gena.RemoteGENASubscription;
 import org.jupnp.model.meta.DeviceDetails;
@@ -285,8 +286,10 @@ class RemoteItems extends RegistryItems<RemoteDevice, RemoteGENASubscription> {
         // Renew outgoing subscriptions
         Set<RemoteGENASubscription> expiredOutgoingSubscriptions = new HashSet();
         for (RegistryItem<String, RemoteGENASubscription> item : getSubscriptionItems()) {
-            if (item.getExpirationDetails().hasExpired(true)) {
+            ExpirationDetails expirationDetails = item.getExpirationDetails();
+            if (expirationDetails.getRenewAttempts() < 1 && expirationDetails.hasExpired(true)) {
                 expiredOutgoingSubscriptions.add(item.getItem());
+                expirationDetails.renewAttempted();
             }
         }
         for (RemoteGENASubscription subscription : expiredOutgoingSubscriptions) {

--- a/bundles/org.jupnp/src/main/java/org/jupnp/transport/impl/blocking/BlockingServlet.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/transport/impl/blocking/BlockingServlet.java
@@ -59,8 +59,8 @@ public class BlockingServlet extends HttpServlet {
 
         final long startTime = System.currentTimeMillis();
         final int counter = mCounter++;
-        log.info(String.format("HttpServlet.service(): id: %3d, request URI: %s", counter, req.getRequestURI()));
-        log.debug("Handling Servlet request synchronously: " + req);
+        log.trace(String.format("HttpServlet.service(): id: %3d, request URI: %s", counter, req.getRequestURI()));
+        log.trace("Handling Servlet request synchronously: " + req);
 
         FauxAsyncContext asyncContext = new FauxAsyncContext(req, resp);
         asyncContext.setTimeout(configuration.getAsyncTimeoutSeconds() * 1000);
@@ -81,7 +81,7 @@ public class BlockingServlet extends HttpServlet {
         long duration = System.currentTimeMillis() - startTime;
 
         if (asyncContext.isCompleted()) {
-            log.info(String.format("BlockingServlet completed: id: %3d, duration: %,4d", counter, duration));
+            log.trace(String.format("BlockingServlet completed: id: %3d, duration: %,4d", counter, duration));
         } else {
             // set internal server error as response code when timeout
             // as per AsyncContext specification

--- a/tests/core/src/test/java/org/jupnp/test/gena/EventXMLProcessingTest.java
+++ b/tests/core/src/test/java/org/jupnp/test/gena/EventXMLProcessingTest.java
@@ -17,9 +17,15 @@ package org.jupnp.test.gena;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
+import java.io.IOException;
+import java.io.StringReader;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
 
 import org.jupnp.mock.MockUpnpService;
 import org.jupnp.mock.MockUpnpServiceConfiguration;
@@ -33,28 +39,25 @@ import org.jupnp.model.meta.LocalService;
 import org.jupnp.model.meta.RemoteDevice;
 import org.jupnp.model.meta.RemoteService;
 import org.jupnp.model.state.StateVariableValue;
+import org.jupnp.test.data.SampleData;
 import org.jupnp.transport.impl.GENAEventProcessorImpl;
 import org.jupnp.transport.spi.GENAEventProcessor;
-import org.jupnp.test.data.SampleData;
 import org.testng.annotations.Test;
-
+import org.w3c.dom.Document;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
 
 public class EventXMLProcessingTest {
 
-    public static final String EVENT_MSG =
-        "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"yes\"?>" +
-            "<e:propertyset xmlns:e=\"urn:schemas-upnp-org:event-1-0\">" +
-            "<e:property>" +
-            "<Status>0</Status>" +
-            "</e:property>" +
-            "<e:property>" +
-            "<SomeVar></SomeVar>" +
-            "</e:property>" +
-            "</e:propertyset>";
+    public static final String EVENT_MSG = "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"yes\"?>"
+            + "<e:propertyset xmlns:e=\"urn:schemas-upnp-org:event-1-0\">" + "<e:property>" + "<Status>0</Status>"
+            + "</e:property>" + "<e:property>" + "<SomeVar></SomeVar>" + "</e:property>" + "</e:propertyset>";
 
     @Test
     public void writeReadRequest() throws Exception {
-        MockUpnpService upnpService = new MockUpnpService(new MockUpnpServiceConfiguration(){
+        MockUpnpService upnpService = new MockUpnpService(new MockUpnpServiceConfiguration() {
             @Override
             public GENAEventProcessor getGenaEventProcessor() {
                 return new GENAEventProcessorImpl();
@@ -68,35 +71,36 @@ public class EventXMLProcessingTest {
         LocalDevice localDevice = GenaSampleData.createTestDevice(GenaSampleData.LocalTestService.class);
         LocalService localService = localDevice.getServices()[0];
 
-        List<URL> urls = new ArrayList() {{
-            add(SampleData.getLocalBaseURL());
-        }};
-        
-        LocalGENASubscription subscription =
-                new LocalGENASubscription(localService, 1800, urls) {
-                    public void failed(Exception ex) {
-                        throw new RuntimeException("TEST SUBSCRIPTION FAILED: " + ex);
-                    }
+        List<URL> urls = new ArrayList() {
+            {
+                add(SampleData.getLocalBaseURL());
+            }
+        };
 
-                    public void ended(CancelReason reason) {
+        LocalGENASubscription subscription = new LocalGENASubscription(localService, 1800, urls) {
+            public void failed(Exception ex) {
+                throw new RuntimeException("TEST SUBSCRIPTION FAILED: " + ex);
+            }
 
-                    }
+            public void ended(CancelReason reason) {
 
-                    public void established() {
+            }
 
-                    }
+            public void established() {
 
-                    public void eventReceived() {
+            }
 
-                    }
-                };
+            public void eventReceived() {
 
-        OutgoingEventRequestMessage outgoingCall =
-                new OutgoingEventRequestMessage(subscription, subscription.getCallbackURLs().get(0));
+            }
+        };
+
+        OutgoingEventRequestMessage outgoingCall = new OutgoingEventRequestMessage(subscription,
+                subscription.getCallbackURLs().get(0));
 
         upnpService.getConfiguration().getGenaEventProcessor().writeBody(outgoingCall);
 
-        assertEquals(outgoingCall.getBody(), EVENT_MSG);
+        assertTrue(xmlDocumentsEqual((String) outgoingCall.getBody(), EVENT_MSG));
 
         StreamRequestMessage incomingStream = new StreamRequestMessage(outgoingCall);
 
@@ -123,5 +127,68 @@ public class EventXMLProcessingTest {
         assertTrue(gotValueOne && gotValueTwo);
     }
 
+    /**
+     * Used to compare the two given xmls for equality regardless of property order.
+     * 
+     * @param xml1
+     * @param xml2
+     * @return
+     * @throws SAXException
+     * @throws IOException
+     * @throws ParserConfigurationException
+     */
+    private boolean xmlDocumentsEqual(String xml1, String xml2)
+            throws SAXException, IOException, ParserConfigurationException {
+        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        factory.setNamespaceAware(true);
+
+        InputSource is1 = new InputSource();
+        is1.setCharacterStream(new StringReader(xml1));
+
+        InputSource is2 = new InputSource();
+        is2.setCharacterStream(new StringReader(xml2));
+
+        DocumentBuilder builder = factory.newDocumentBuilder();
+
+        Document document1 = builder.parse(is1);
+        document1.normalizeDocument();
+
+        Document document2 = builder.parse(is2);
+        document2.normalizeDocument();
+
+        boolean childrenEq = nodeListsEqual(document1.getChildNodes(), document2.getChildNodes());
+
+        if (!childrenEq) {
+            return false;
+        }
+
+        document1.removeChild(document1.getChildNodes().item(0));
+        document2.removeChild(document2.getChildNodes().item(0));
+        
+        return document1.isEqualNode(document2);
+    }
+
+    private boolean nodeListsEqual(NodeList childNodes1, NodeList childNodes2) {
+        
+        // compare the two node sets
+        for (int i = 0; i < childNodes1.getLength(); i++) {
+            Node item1 = childNodes1.item(i);
+            boolean found = false;
+            for (int j = 0; j < childNodes2.getLength(); j++) {
+                Node item2 = childNodes1.item(j);
+                if (item1.isEqualNode(item2)) {
+                    found = nodeListsEqual(item1.getChildNodes(), item2.getChildNodes());
+                    break;
+                }
+            }
+
+            if (!found) {
+                return false;
+            }
+
+        }
+        
+        return true;
+    }
 
 }


### PR DESCRIPTION
…stryImpl.

Fixed problems with subscription renewal failures that could possibly flood the queue ( made certain only 1 renew attempt is done if a RemoteItem is halftime expired).
Modified QueueingThreadPoolExecutor to make sure that when rejected executions are present in the queue, we add the concurrently incoming executions to the end of it, so that we don't execute them before the already queued ones.
Changed logging in BlockingServlet to trace.

Signed-off-by: IVAN GEORGIEV ILIEV <ivan.iliev@musala.com>