### PR TITLE
Enhanced jUPnPTool for easier use

### DIFF
--- a/tools/org.jupnp.tool/src/main/java/org/jupnp/tool/cli/CommandLineArgs.java
+++ b/tools/org.jupnp.tool/src/main/java/org/jupnp/tool/cli/CommandLineArgs.java
@@ -58,7 +58,7 @@ public class CommandLineArgs {
 class SearchCommandArgs {
 
 	@Parameter(names = { "--timeout", "-t" }, description = "The timeout when search will be finished")
-	public Integer timeout = 20;
+	public Integer timeout = 10;
 
 	@Parameter(names = { "--sort",
 			"-s" }, description = "Sort using {none|ip|model|serialNumber|manufacturer|udn}", validateWith = SearchCommandSortByValidator.class)

--- a/tools/org.jupnp.tool/src/main/resources/logback-enabled.xml
+++ b/tools/org.jupnp.tool/src/main/resources/logback-enabled.xml
@@ -10,12 +10,31 @@
 			<pattern>%d{HH:mm:ss.SSS} [%-20thread] %-5level %-70(%logger{36}.%M:%line) - %msg%n
 			</pattern>
 		</encoder>
+		<target>System.out</target>
+	</appender>
+
+	<appender name="STDERR" class="ch.qos.logback.core.ConsoleAppender">
+		<!-- encoders are assigned the type ch.qos.logback.classic.encoder.PatternLayoutEncoder 
+			by default -->
+		<encoder>
+			<pattern>%d{HH:mm:ss.SSS} [%-20thread] %-5level %-70(%logger{36}.%M:%line) - %msg%n
+			</pattern>
+		</encoder>
+		<target>System.err</target>
 	</appender>
 
 	<appender name="PLAIN_STDOUT" class="ch.qos.logback.core.ConsoleAppender">
 		<encoder>
 			<pattern>%msg%n</pattern>
 		</encoder>
+		<target>System.out</target>
+	</appender>
+
+	<appender name="PLAIN_STDERR" class="ch.qos.logback.core.ConsoleAppender">
+		<encoder>
+			<pattern>%msg%n</pattern>
+		</encoder>
+		<target>System.err</target>
 	</appender>
 
 	<logger name="org.apache.http" level="ERROR" />
@@ -28,7 +47,7 @@
 	</logger>
 
 	<root level="DEBUG">
-		<appender-ref ref="STDOUT" />
+		<appender-ref ref="STDERR" />
 	</root>
 
 </configuration>

--- a/tools/org.jupnp.tool/src/main/resources/logback.xml
+++ b/tools/org.jupnp.tool/src/main/resources/logback.xml
@@ -7,23 +7,47 @@
 		<!-- encoders are assigned the type ch.qos.logback.classic.encoder.PatternLayoutEncoder 
 			by default -->
 		<encoder>
-			<pattern>%d{HH:mm:ss.SSS} [%-20thread] %-5level %-40logger{36} - %msg%n
+			<pattern>%d{HH:mm:ss.SSS} [%-20thread] %-5level %-70(%logger{36}.%M:%line) - %msg%n
 			</pattern>
 		</encoder>
+		<target>System.out</target>
 	</appender>
-	
+
+	<appender name="STDERR" class="ch.qos.logback.core.ConsoleAppender">
+		<!-- encoders are assigned the type ch.qos.logback.classic.encoder.PatternLayoutEncoder 
+			by default -->
+		<encoder>
+			<pattern>%d{HH:mm:ss.SSS} [%-20thread] %-5level %-70(%logger{36}.%M:%line) - %msg%n
+			</pattern>
+		</encoder>
+		<target>System.err</target>
+	</appender>
+
 	<appender name="PLAIN_STDOUT" class="ch.qos.logback.core.ConsoleAppender">
 		<encoder>
 			<pattern>%msg%n</pattern>
 		</encoder>
+		<target>System.out</target>
 	</appender>
-	
+
+	<appender name="PLAIN_STDERR" class="ch.qos.logback.core.ConsoleAppender">
+		<encoder>
+			<pattern>%msg%n</pattern>
+		</encoder>
+		<target>System.err</target>
+	</appender>
+
+	<logger name="org.apache.http" level="ERROR" />
+	<logger name="org.apache.http.client" level="WARN" />
+	<!-- set to DEBUG for on the wire logging -->
+	<logger name="org.apache.http.wire" level="WARN" />
+
 	<logger name="org.jupnp.tool.cli.stats" level="INFO" additivity="false">
 		<appender-ref ref="PLAIN_STDOUT" />
 	</logger>
 
 	<root level="OFF">
-		<appender-ref ref="STDOUT" />
+		<appender-ref ref="STDERR" />
 	</root>
 
 </configuration>


### PR DESCRIPTION
* set default timeout of search command to 10 sec
* enhanced logging: console output goes always to stdout, all logs goes to stderr
* you can pipe the logs now its separate file for better readability

Signed-off-by: Jochen Hiller <jo.hiller@googlemail.com>