### PR TITLE
remove annoying messages on stderr

### DIFF
--- a/bundles/org.jupnp/src/main/java/org/jupnp/xml/SAXParser.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/xml/SAXParser.java
@@ -65,16 +65,18 @@ public class SAXParser {
 
     protected XMLReader create() {
         try {
+            final XMLReader xmlReader;
             if (getSchemaSources() != null) {
                 // Jump through all the hoops and create a validating reader
-                SAXParserFactory factory = SAXParserFactory.newInstance();
+                final SAXParserFactory factory = SAXParserFactory.newInstance();
                 factory.setNamespaceAware(true);
                 factory.setSchema(createSchema(getSchemaSources()));
-                XMLReader xmlReader = factory.newSAXParser().getXMLReader();
-                xmlReader.setErrorHandler(getErrorHandler());
-                return xmlReader;
+                xmlReader = factory.newSAXParser().getXMLReader();
+            } else {
+                xmlReader = XMLReaderFactory.createXMLReader();
             }
-            return XMLReaderFactory.createXMLReader();
+            xmlReader.setErrorHandler(getErrorHandler());
+            return xmlReader;
         } catch (Exception ex) {
             throw new RuntimeException(ex);
         }


### PR DESCRIPTION
The error handler for the XML reader has been set only in one of the two branches.

This change removes messages like
```text
[Fatal Error] :1:3: The markup in the document preceding the root element must be well-formed.
```
from the standard error output.

Related to: https://github.com/openhab/openhab-docker/issues/23