### PR TITLE
Boolean must not be used as a synchronization object. 

### DIFF
--- a/bundles/org.jupnp/src/main/java/org/jupnp/UpnpServiceImpl.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/UpnpServiceImpl.java
@@ -57,6 +57,8 @@ public class UpnpServiceImpl implements UpnpService {
     protected boolean isConfigured = false;
     protected Boolean isRunning = false;
 
+    private final Object LOCK = new Object();
+
     protected UpnpServiceConfiguration configuration;
     protected ProtocolFactory protocolFactory;
     protected Registry registry;
@@ -164,7 +166,7 @@ public class UpnpServiceImpl implements UpnpService {
         Runnable shutdown = new Runnable() {
             @Override
             public void run() {
-                synchronized (isRunning) {
+                synchronized (LOCK) {
                     if (isRunning) {
                         log.info("Shutting down UPnP service...");
                         shutdownRegistry();
@@ -238,7 +240,7 @@ public class UpnpServiceImpl implements UpnpService {
     }
 
     public void startup() {
-        synchronized (isRunning) {
+        synchronized (LOCK) {
             if (!isRunning) {
                 log.info("Starting UPnP service...");
 

--- a/bundles/org.jupnp/src/main/java/org/jupnp/UpnpServiceImpl.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/UpnpServiceImpl.java
@@ -57,7 +57,7 @@ public class UpnpServiceImpl implements UpnpService {
     protected boolean isConfigured = false;
     protected Boolean isRunning = false;
 
-    private final Object LOCK = new Object();
+    private final Object lock = new Object();
 
     protected UpnpServiceConfiguration configuration;
     protected ProtocolFactory protocolFactory;
@@ -166,7 +166,7 @@ public class UpnpServiceImpl implements UpnpService {
         Runnable shutdown = new Runnable() {
             @Override
             public void run() {
-                synchronized (LOCK) {
+                synchronized (lock) {
                     if (isRunning) {
                         log.info("Shutting down UPnP service...");
                         shutdownRegistry();
@@ -240,7 +240,7 @@ public class UpnpServiceImpl implements UpnpService {
     }
 
     public void startup() {
-        synchronized (LOCK) {
+        synchronized (lock) {
             if (!isRunning) {
                 log.info("Starting UPnP service...");
 


### PR DESCRIPTION
According https://www.securecoding.cert.org/confluence/display/java/LCK01-J.+Do+not+synchronize+on+objects+that+may+be+reused it is not allowed to use Boolean as synchronization objects. This might lead to possible deadlocks.

Signed-off-by: Andre Fuechsel <andre.fuechsel@telekom.de>