### PR TITLE
Refactor synchronization in RegistryImpl

### DIFF
--- a/bundles/org.jupnp/src/main/java/org/jupnp/registry/RemoteItems.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/registry/RemoteItems.java
@@ -127,7 +127,7 @@ class RemoteItems extends RegistryItems<RemoteDevice, RemoteGENASubscription> {
         }
 
         RemoteDevice registeredRemoteDevice = get(rdIdentity.getUdn(), false);
-                  
+
         if (registeredRemoteDevice != null) {
 
             // check for IP address change

--- a/tests/core/src/test/java/example/registry/RegistryAsyncTest.java
+++ b/tests/core/src/test/java/example/registry/RegistryAsyncTest.java
@@ -1,0 +1,96 @@
+package example.registry;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+
+import java.lang.management.ManagementFactory;
+import java.lang.management.ThreadMXBean;
+
+import org.jupnp.mock.MockUpnpService;
+import org.jupnp.model.ValidationException;
+import org.jupnp.model.meta.DeviceIdentity;
+import org.jupnp.model.meta.LocalDevice;
+import org.jupnp.model.meta.RemoteDevice;
+import org.jupnp.model.meta.RemoteDeviceIdentity;
+import org.jupnp.model.types.UDN;
+import org.jupnp.registry.Registry;
+import org.testng.annotations.Test;
+
+public class RegistryAsyncTest {
+
+    private static final int DEVICE_COUNT = 20;
+    private static final String[] UDNS = new String[DEVICE_COUNT];
+
+    @Test
+    public void addMultipleLocalDevices() throws ValidationException, InterruptedException {
+
+        for (int i = 0; i < UDNS.length; i++) {
+            UDNS[i] = "my-device-" + i;
+        }
+
+        MockUpnpService upnpService = new MockUpnpService();
+        upnpService.startup();
+        final Registry registry = upnpService.getRegistry();
+
+        new Thread(new RegistryClient(registry, 0)).start();
+        new Thread(new RegistryClient(registry, 1)).start();
+        new Thread(new RegistryClient(registry, 2)).start();
+        new Thread(new RegistryClient(registry, 3)).start();
+
+        Thread.sleep(5000);
+
+        ThreadMXBean threadMXBean = ManagementFactory.getThreadMXBean();
+        long[] deadlockedThreads = threadMXBean.findDeadlockedThreads();
+
+        assertNull(deadlockedThreads);
+
+        assertEquals(registry.getLocalDevices().size() + registry.getRemoteDevices().size(), DEVICE_COUNT);
+
+        for (LocalDevice localDevice : registry.getLocalDevices()) {
+            RemoteDevice remoteDevice = registry.getRemoteDevice(localDevice.getIdentity().getUdn(), true);
+            assertNull(remoteDevice);
+        }
+    }
+
+    private static LocalDevice createLocalDevice(String udn) throws ValidationException {
+        DeviceIdentity identity = new DeviceIdentity(new UDN(udn));
+        return new LocalDevice(identity);
+    }
+
+    private static RemoteDevice createRemoteDevice(String udn) throws ValidationException {
+        RemoteDeviceIdentity identity = new RemoteDeviceIdentity(new UDN(udn), 16, null, null, null);
+        return new RemoteDevice(identity);
+    }
+
+    private static class RegistryClient implements Runnable {
+
+        private Registry registry;
+        private int threadNumber;
+
+        public RegistryClient(Registry registry, int threadNumber) {
+            this.registry = registry;
+            this.threadNumber = threadNumber;
+        }
+
+        @Override
+        public void run() {
+            try {
+                /*
+                 * Each thread has a different starting point and tries to add each device multiple times as both local and
+                 * remote device.
+                 */
+                for (int i = threadNumber * 7; i < 100; i++) {
+                    if (i + threadNumber % 2 == 0) {
+                        LocalDevice localDevice = createLocalDevice(UDNS[i % DEVICE_COUNT]);
+                        registry.addDevice(localDevice);
+                    } else {
+                        RemoteDevice remoteDevice = createRemoteDevice(UDNS[i % DEVICE_COUNT]);
+                        registry.addDevice(remoteDevice);
+                    }
+
+                }
+            } catch (ValidationException e) {
+            }
+        }
+    }
+}


### PR DESCRIPTION
_RegistryImpl_ uses several collections and helper classes - _registryListeners_, _resourceItems_, _pendingExecutions_, _remoteItems_, _localItems_. Each usage of these collections is wrapped inside a synchronized block. This causes several problems:
1. _addDevice(LocalDevice)_ synchronizes on _localItems_ but also tries to check if the device already exists in _remoteItems_ so it also synchronizes on _remoteItems_.
_addDevice(RemoteDevice)_ synchronizes on _remoteItems_ but also tries to check if the device already exists in _localItems_ so it also synchronizes on _localItems_. If these methods are called at the same time by 2 threads these threads deadlock.
2. The methods to check if a device is already in the registry are used a lot by the async tasks that handle search responses and they block each other.

The PR includes the following changes:
1. Replaced the synchronized blocks on _remoteItems_ and _localItems_ with ReentrantReadWriteLocks so the reads don't block other reads.
2. Fixed the methods _addDevice(LocalDevice)_ and _addDevice(RemoteDevice)_ to acquire both locks in the same order so they don't deadlock.
3. Changed _registryListeners_ and _resourceItems_ to concurrent collections because it will optimize performance and not change the current behavior.