### PR TITLE
Improved initial search time

### DIFF
--- a/bundles/org.jupnp/OSGI-INF/metatype/UpnpServiceConfig.xml
+++ b/bundles/org.jupnp/OSGI-INF/metatype/UpnpServiceConfig.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<metatype:MetaData xmlns:metatype="http://www.osgi.org/xmlns/metatype/v1.1.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://www.osgi.org/xmlns/metatype/v1.1.0 http://www.osgi.org/xmlns/metatype/v1.1.0">
+
+	<OCD name="jUPnP service configuration" id="org.jupnp.upnpservice"
+		description="Configuration for jUPnP OSGi service">
+		<AD name="initialSearchEnabled" id="initialSearchEnabled"
+			type="Boolean" default="true"
+			description="Enable initial search when starting jUPnP service." />
+	</OCD>
+
+	<Designate pid="org.jupnp.upnpservice">
+		<Object ocdref="org.jupnp.upnpservice" />
+	</Designate>
+
+</metatype:MetaData>

--- a/bundles/org.jupnp/src/main/java/org/jupnp/UpnpServiceImpl.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/UpnpServiceImpl.java
@@ -15,6 +15,7 @@
 package org.jupnp;
 
 import java.lang.Thread.UncaughtExceptionHandler;
+import java.util.Map;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
@@ -56,6 +57,7 @@ public class UpnpServiceImpl implements UpnpService {
 
     protected boolean isConfigured = false;
     protected Boolean isRunning = false;
+    private volatile boolean isInitialSearchEnabled = true;
 
     private final Object lock = new Object();
 
@@ -264,14 +266,24 @@ public class UpnpServiceImpl implements UpnpService {
 
                 isRunning = true;
 
-                controlPoint.search(new STAllHeader());
+                if (isInitialSearchEnabled) {
+                    controlPoint.search(new STAllHeader());
+                }
             }
         }
     }
 
-    protected void activate() {
+    private void setConfigProperties(Map<String, Object> configProperties) {
+        Object prop = configProperties.get("initialSearchEnabled");
+        if (prop instanceof Boolean) {
+            isInitialSearchEnabled = (boolean) prop;
+        }
+    }
+
+    protected void activate(Map<String, Object> configProperties) {
         scheduledFuture = null;
         scheduledExecutorService = createExecutor();
+        setConfigProperties(configProperties);
         startup();
     }
 

--- a/bundles/org.jupnp/src/main/java/org/jupnp/protocol/async/ReceivingSearchResponse.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/protocol/async/ReceivingSearchResponse.java
@@ -91,9 +91,15 @@ public class ReceivingSearchResponse extends ReceivingAsync<IncomingSearchRespon
 
         // Unfortunately, we always have to retrieve the descriptor because at this point we
         // have no idea if it's a root or embedded device
-        getUpnpService().getConfiguration().getAsyncProtocolExecutor().execute(
-                new RetrieveRemoteDescriptors(getUpnpService(), rd)
-        );
+
+        if (RetrieveRemoteDescriptors.isRetrievalInProgress(rd)) {
+            log.trace("Skip submitting task, active retrieval for URL already in progress:{}",
+                    rd.getIdentity().getDescriptorURL());
+            return;
+        }
+
+        getUpnpService().getConfiguration().getAsyncProtocolExecutor()
+                .execute(new RetrieveRemoteDescriptors(getUpnpService(), rd));
 
     }
 

--- a/bundles/org.jupnp/src/main/java/org/jupnp/protocol/async/SendingSearch.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/protocol/async/SendingSearch.java
@@ -101,7 +101,7 @@ public class SendingSearch extends SendingAsync {
     }
 
     public int getBulkRepeat() {
-        return 5; // UDA 1.0 says "repeat more than once"
+        return 3; // UDA 1.0 says "repeat more than once"
     }
 
     public int getBulkIntervalMilliseconds() {

--- a/tests/core/src/test/java/example/controlpoint/SearchExecuteTest.java
+++ b/tests/core/src/test/java/example/controlpoint/SearchExecuteTest.java
@@ -195,7 +195,7 @@ public class SearchExecuteTest {
     }
 
     protected void assertMessages(MockUpnpService upnpService, UpnpHeader header) throws Exception {
-        assertEquals(upnpService.getRouter().getOutgoingDatagramMessages().size(), 5);
+        assertEquals(upnpService.getRouter().getOutgoingDatagramMessages().size(), 3);
         for (UpnpMessage msg : upnpService.getRouter().getOutgoingDatagramMessages()) {
             assertSearchMessage(msg, header);
         }


### PR DESCRIPTION
The option to do a search upon bundle activation is now configurable

Upnp search now sends less broadcast messages
- Tested the change in a network with 11 devices and a network with 140 devices and the number of dicovered devices after the initial search is the same but the number of async tasks is reduced

Added an optimization to ReceivingSearchResponse to skip creating a descriptor retrieval task if a task for the same descriptor URL is already created.
- This change reduces the number of tasks that are executed without doing actual work

Replaced the CopyOnWriteSet in RetrieveRemoteDescriptors with a ConcurrentHashMap
- With the previous implementation it was possible (most likely in a network with many devices) to do an HTTP request and parse the same descriptor XML multiple times. For example in my network with 140 devices there were 190 descriptor HTTP requests.