### PR TITLE
Ignore point to point interfaces

### DIFF
--- a/bundles/org.jupnp/src/main/java/org/jupnp/transport/impl/NetworkAddressFactoryImpl.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/transport/impl/NetworkAddressFactoryImpl.java
@@ -376,6 +376,11 @@ public class NetworkAddressFactoryImpl implements NetworkAddressFactory {
             return false;
         }
 
+        if (iface.isPointToPoint()) {
+            log.trace("Skipping point-to-point network interface: {}", iface.getDisplayName());
+            return false;
+        }
+
         if (iface.getName().toLowerCase(Locale.ENGLISH).startsWith("vmnet") || (iface.getDisplayName() != null
                 && iface.getDisplayName().toLowerCase(Locale.ENGLISH).contains("vmnet"))) {
             log.trace("Skipping network interface (VMWare): {}", iface.getDisplayName());


### PR DESCRIPTION
If there is point-to-point interface configured (e.g. a VPN), the following log messages were produced en masse:

```
java.io.IOException: No route to host (sendto failed)
	at java.net.PlainDatagramSocketImpl.send(Native Method)
	at java.net.DatagramSocket.send(DatagramSocket.java:693)
	at org.jupnp.transport.impl.DatagramIOImpl.send(DatagramIOImpl.java:156)
	at org.jupnp.transport.impl.DatagramIOImpl.send(DatagramIOImpl.java:149)
	at org.jupnp.transport.RouterImpl.send(RouterImpl.java:300)
	at org.jupnp.protocol.async.SendingSearch.execute(SendingSearch.java:90)
	at org.jupnp.protocol.SendingAsync.run(SendingAsync.java:52)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
```

They generally do not support forwarding multicast packets hence there also is no route configured. There is no point in even trying to send a broadcast to them...

With this change, that won't happen anymore: it lets jUPnP ignore point-to-point interfaces. 

Signed-off-by: Simon Kaufmann <simon.kfm@googlemail.com>
