### PR TITLE
stop tampering with the preferIPv4Stack system property

### DIFF
--- a/bundles/org.jupnp/src/main/java/org/jupnp/transport/impl/NetworkAddressFactoryImpl.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/transport/impl/NetworkAddressFactoryImpl.java
@@ -76,9 +76,6 @@ public class NetworkAddressFactoryImpl implements NetworkAddressFactory {
     }
 
     public NetworkAddressFactoryImpl(int streamListenPort, int multicastResponsePort) throws InitializationException {
-
-        System.setProperty("java.net.preferIPv4Stack", "true");
-
         String useInterfacesString = System.getProperty(SYSTEM_PROPERTY_NET_IFACES);
         if (useInterfacesString != null) {
             String[] userInterfacesStrings = useInterfacesString.split(",");


### PR DESCRIPTION
It might be a limitation of this library that it only works with IPv4, but it comes as a pretty big surprise that it is actually _changing_ this property. 

Signed-off-by: Simon Kaufmann <simon.kfm@googlemail.com>