### PR TITLE
Clean up tool.jar dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -201,13 +201,6 @@
                 </exclusion>
             </exclusions>
         </dependency>
-		<dependency>
-		  <groupId>com.sun</groupId>
-		  <artifactId>tools</artifactId>
-		  <version>1.6.0</version>
-		  <scope>system</scope>
-		  <systemPath>${java.home}/../lib/tools.jar</systemPath>
-		</dependency>
     </dependencies>
 
     <profiles>


### PR DESCRIPTION
The library builds fine w/o the system specific tool.jar dependency.

Signed-off-by: Henning Treu <henning.treu@telekom.de>