### PR TITLE
Increased upper limit for thread count of Jetty client

### DIFF
--- a/bundles/org.jupnp/src/main/java/org/jupnp/transport/impl/jetty/JettyStreamClientImpl.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/transport/impl/jetty/JettyStreamClientImpl.java
@@ -66,7 +66,10 @@ public class JettyStreamClientImpl extends AbstractStreamClient<StreamClientConf
         httpClient.setConnectTimeout((getConfiguration().getTimeoutSeconds() + 5) * 1000);
         httpClient.setMaxConnectionsPerDestination(2);
 
-        final QueuedThreadPool queuedThreadPool = createThreadPool("jupnp-jetty-client", 5, 5, 60000);
+        int cpus = Runtime.getRuntime().availableProcessors();
+        int maxThreads = 5 * cpus;
+        
+        final QueuedThreadPool queuedThreadPool = createThreadPool("jupnp-jetty-client", 5, maxThreads, 60000);
 
         httpClient.setExecutor(queuedThreadPool);
 


### PR DESCRIPTION
This fixes "IllegalStateException: Insufficient configured threads" probems, see https://community.openhab.org/t/sonos-2-4-0-binding-broken-in-milestone-m8/59647

Signed-off-by: Kai Kreuzer <kai@openhab.org>