### PR TITLE
Remove broken javadoc processes

### DIFF
--- a/bundles/pom.xml
+++ b/bundles/pom.xml
@@ -91,6 +91,7 @@
 					</environments>
 				</configuration>
 			</plugin>
+          <!--
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-javadoc-plugin</artifactId>
@@ -104,11 +105,14 @@
               </execution>
             </executions>
             <configuration>
+              -->
               <!-- 'javadoc.opts' project property is set by the 'doclint-java8-disable' profile. It is important to keep 'javadoc' profile declaration after the declaration of 'doclint-java8-disable' profile. -->
+              <!--
               <additionalparam>${javadoc.opts}</additionalparam>
               <excludePackageNames>*.internal.*,nl.*</excludePackageNames>
             </configuration>
           </plugin>
+          -->
 		</plugins>
 
 		<pluginManagement>

--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -34,6 +34,7 @@
           </execution>
         </executions>
       </plugin>
+          <!--
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-javadoc-plugin</artifactId>
@@ -47,11 +48,14 @@
               </execution>
             </executions>
             <configuration>
+              -->
               <!-- 'javadoc.opts' project property is set by the 'doclint-java8-disable' profile. It is important to keep 'javadoc' profile declaration after the declaration of 'doclint-java8-disable' profile. -->
+              <!--
               <additionalparam>${javadoc.opts}</additionalparam>
               <excludePackageNames>*.internal.*,nl.*</excludePackageNames>
             </configuration>
           </plugin>
+          -->
         </plugins>
         <pluginManagement>
           <plugins>


### PR DESCRIPTION
I've removed some calls to create Javadocs because they are failing with recent versions of Java/Javadoc. This is mostly because Javadoc started shipping with a very strict doclint feature, and the process to disable it via Maven seems to change with every release.

The real problem here is that a lot of the documentation has been left to rot through several large refactors, so I would consider it reasonable to not generate Javadocs anyway.