### PR TITLE
Add retryAfterSeconds/maxRequests - Disable HTTPS from UPnP action calls

### DIFF
--- a/bundles/org.jupnp/src/main/java/org/jupnp/UpnpServiceConfiguration.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/UpnpServiceConfiguration.java
@@ -108,12 +108,14 @@ public interface UpnpServiceConfiguration {
     public ExecutorService getStreamServerExecutorService();
 
     /**
-     * @return The shared implementation of {@link org.jupnp.binding.xml.DeviceDescriptorBinder} for the UPnP 1.0 Device Architecture..
+     * @return The shared implementation of {@link org.jupnp.binding.xml.DeviceDescriptorBinder} for the UPnP 1.0 Device
+     *         Architecture..
      */
     public DeviceDescriptorBinder getDeviceDescriptorBinderUDA10();
 
     /**
-     * @return The shared implementation of {@link org.jupnp.binding.xml.ServiceDescriptorBinder} for the UPnP 1.0 Device Architecture..
+     * @return The shared implementation of {@link org.jupnp.binding.xml.ServiceDescriptorBinder} for the UPnP 1.0
+     *         Device Architecture..
      */
     public ServiceDescriptorBinder getServiceDescriptorBinderUDA10();
 
@@ -142,7 +144,7 @@ public interface UpnpServiceConfiguration {
      * @return The time in milliseconds to wait between each registry maintenance operation.
      */
     public int getRegistryMaintenanceIntervalMillis();
-    
+
     /**
      * Optional setting for flooding alive NOTIFY messages for local devices.
      * <p>
@@ -228,7 +230,8 @@ public interface UpnpServiceConfiguration {
     public Executor getAsyncProtocolExecutor();
 
     /**
-     * @return The executor service which runs the processing of synchronous aspects of the UPnP stack (description, control, GENA).
+     * @return The executor service which runs the processing of synchronous aspects of the UPnP stack (description,
+     *         control, GENA).
      */
     public ExecutorService getSyncProtocolExecutorService();
 
@@ -246,6 +249,8 @@ public interface UpnpServiceConfiguration {
      * @return The executor which runs the notification threads of registry listeners.
      */
     public Executor getRegistryListenerExecutor();
+
+    public int getMaxRequests();
 
     /**
      * Called by the {@link org.jupnp.UpnpService} on shutdown, useful to e.g. shutdown thread pools.

--- a/bundles/org.jupnp/src/main/java/org/jupnp/mock/MockRouter.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/mock/MockRouter.java
@@ -56,8 +56,7 @@ public class MockRouter implements Router {
     protected UpnpServiceConfiguration configuration;
     protected ProtocolFactory protocolFactory;
 
-    public MockRouter(UpnpServiceConfiguration configuration,
-                      ProtocolFactory protocolFactory) {
+    public MockRouter(UpnpServiceConfiguration configuration, ProtocolFactory protocolFactory) {
         this.configuration = configuration;
         this.protocolFactory = protocolFactory;
     }
@@ -92,6 +91,11 @@ public class MockRouter implements Router {
     }
 
     @Override
+    public boolean autoRestart() throws RouterException {
+        return false;
+    }
+
+    @Override
     public void handleStartFailure(InitializationException ex) throws InitializationException {
     }
 
@@ -100,37 +104,37 @@ public class MockRouter implements Router {
         // Simulate an active stream server, otherwise the notification/search response
         // protocols won't even run
         try {
-            return Arrays.asList(
-                new NetworkAddress(
-                    InetAddress.getByName("127.0.0.1"),
-                    NetworkAddressFactoryImpl.DEFAULT_TCP_HTTP_LISTEN_PORT
-                )
-            );
+            return Arrays.asList(new NetworkAddress(InetAddress.getByName("127.0.0.1"),
+                    NetworkAddressFactoryImpl.DEFAULT_TCP_HTTP_LISTEN_PORT));
         } catch (UnknownHostException ex) {
             throw new RuntimeException(ex);
         }
     }
 
+    @Override
     public void received(IncomingDatagramMessage msg) {
         incomingDatagramMessages.add(msg);
     }
 
+    @Override
     public void received(UpnpStream stream) {
         receivedUpnpStreams.add(stream);
     }
 
+    @Override
     public void send(OutgoingDatagramMessage msg) throws RouterException {
         outgoingDatagramMessages.add(msg);
     }
 
+    @Override
     public StreamResponseMessage send(StreamRequestMessage msg) throws RouterException {
         sentStreamRequestMessages.add(msg);
         counter++;
-        return getStreamResponseMessages() != null
-            ? getStreamResponseMessages()[counter]
-            : getStreamResponseMessage(msg);
+        return getStreamResponseMessages() != null ? getStreamResponseMessages()[counter]
+                : getStreamResponseMessage(msg);
     }
 
+    @Override
     public void broadcast(byte[] bytes) {
         broadcastedBytes.add(bytes);
     }

--- a/bundles/org.jupnp/src/main/java/org/jupnp/transport/Router.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/transport/Router.java
@@ -14,6 +14,9 @@
 
 package org.jupnp.transport;
 
+import java.net.InetAddress;
+import java.util.List;
+
 import org.jupnp.UpnpServiceConfiguration;
 import org.jupnp.model.NetworkAddress;
 import org.jupnp.model.message.IncomingDatagramMessage;
@@ -23,9 +26,6 @@ import org.jupnp.model.message.StreamResponseMessage;
 import org.jupnp.protocol.ProtocolFactory;
 import org.jupnp.transport.spi.InitializationException;
 import org.jupnp.transport.spi.UpnpStream;
-
-import java.net.InetAddress;
-import java.util.List;
 
 /**
  * Interface of the network transport layer.
@@ -80,13 +80,15 @@ public interface Router {
     /**
      * Disables the router and releases all other resources.
      */
-    void shutdown() throws RouterException ;
+    void shutdown() throws RouterException;
 
     /**
      *
      * @return <code>true</code> if the router is currently enabled.
      */
     boolean isEnabled() throws RouterException;
+
+    boolean autoRestart() throws RouterException;
 
     /**
      * Called by the {@link #enable()} method before it returns.
@@ -112,6 +114,7 @@ public interface Router {
      * the execution completes, the calling thread should be free to handle the next reception as
      * soon as possible.
      * </p>
+     *
      * @param msg The received datagram message.
      */
     public void received(IncomingDatagramMessage msg);
@@ -125,6 +128,7 @@ public interface Router {
      * should be free to process the next reception as soon as possible. Typically this means starting
      * a new thread of execution in this method.
      * </p>
+     *
      * @param stream
      */
     public void received(UpnpStream stream);
@@ -133,6 +137,7 @@ public interface Router {
      * <p>
      * Call this method to send a UDP datagram message.
      * </p>
+     *
      * @param msg The UDP datagram message to send.
      * @throws RouterException if a recoverable error, such as thread interruption, occurs.
      */
@@ -142,6 +147,7 @@ public interface Router {
      * <p>
      * Call this method to send a TCP (HTTP) stream message.
      * </p>
+     *
      * @param msg The TCP (HTTP) stream message to send.
      * @return The response received from the server.
      * @throws RouterException if a recoverable error, such as thread interruption, occurs.
@@ -152,6 +158,7 @@ public interface Router {
      * <p>
      * Call this method to broadcast a UDP message to all hosts on the network.
      * </p>
+     *
      * @param bytes The byte payload of the UDP datagram.
      * @throws RouterException if a recoverable error, such as thread interruption, occurs.
      */

--- a/bundles/org.jupnp/src/main/java/org/jupnp/transport/TransportConfiguration.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/transport/TransportConfiguration.java
@@ -20,7 +20,6 @@ import org.jupnp.transport.spi.StreamClientConfiguration;
 import org.jupnp.transport.spi.StreamServer;
 import org.jupnp.transport.spi.StreamServerConfiguration;
 
-
 /**
  * Interface to abstract a transport implementation.
  *
@@ -35,9 +34,11 @@ public interface TransportConfiguration<SCC extends StreamClientConfiguration, S
      * Creates a {@link StreamClient} using the given {@link ExecutorService} for async calls.
      *
      * @param executorService used to dispatch request/response processing.
+     * @param retryAfterSeconds should be a positive integer or 0 (to disable the functionality); a negative value will
+     *            be ignored.
      * @return created {@link StreamClient}
      */
-    StreamClient<SCC> createStreamClient(final ExecutorService executorService);
+    StreamClient<SCC> createStreamClient(final ExecutorService executorService, int retryAfterSeconds);
 
     /**
      * Creates a {@link StreamServer} using the given {@code listenerPort}.

--- a/bundles/org.jupnp/src/main/java/org/jupnp/transport/impl/jetty/JettyTransportConfiguration.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/transport/impl/jetty/JettyTransportConfiguration.java
@@ -13,28 +13,23 @@ import org.jupnp.transport.spi.StreamServer;
  *
  * @author Victor Toni - initial contribution
  */
-public class JettyTransportConfiguration
-    implements TransportConfiguration {
+public class JettyTransportConfiguration implements TransportConfiguration {
 
     public static final TransportConfiguration INSTANCE = new JettyTransportConfiguration();
 
     @Override
-    public StreamClient createStreamClient(final ExecutorService executorService) {
-        return new JettyStreamClientImpl(
-                new StreamClientConfigurationImpl(
-                        executorService
-                )
-        );
+    public StreamClient createStreamClient(final ExecutorService executorService, int retryAfterSeconds) {
+        StreamClientConfigurationImpl clientConfiguration = new StreamClientConfigurationImpl(executorService);
+        if (retryAfterSeconds >= 0) {
+            clientConfiguration.setRetryAfterSeconds(retryAfterSeconds);
+        }
+        return new JettyStreamClientImpl(clientConfiguration);
     }
 
     @Override
     public StreamServer createStreamServer(final int listenerPort) {
         return new ServletStreamServerImpl(
-                new ServletStreamServerConfigurationImpl(
-                        JettyServletContainer.INSTANCE,
-                        listenerPort
-                )
-            );
+                new ServletStreamServerConfigurationImpl(JettyServletContainer.INSTANCE, listenerPort));
     }
 
 }


### PR DESCRIPTION
Code written by: lolodomo - Merged together and submitted by morph166955

Disable all UPnP action calls based on HTTPS - Fixed #109 

From https://github.com/openhab/openhab-addons/issues/5892

Mentioned in https://community.openhab.org/t/panasonictv-oh3/108124
https://community.openhab.org/t/too-much-time-before-a-sonos-thing-becomes-definitively-online/62214

New setting retryAfterSeconds

New setting maxRequests to trigger an automatic restart of the router after a certain number of executed requests

Get the stack trace in DEBUG or TRACE level

JAR available at https://github.com/morph166955/jupnp/releases/tag/2.6.0

Signed-off-by: morph166955 <rosenblumb@gmail.com>
