### PR TITLE
Adds StreamClientConfiguration to createStreamClient

### DIFF
--- a/bundles/org.jupnp/src/main/java/org/jupnp/DefaultUpnpServiceConfiguration.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/DefaultUpnpServiceConfiguration.java
@@ -175,7 +175,7 @@ public class DefaultUpnpServiceConfiguration implements UpnpServiceConfiguration
     @Override
     @SuppressWarnings("rawtypes")
     public StreamClient createStreamClient() {
-        return transportConfiguration.createStreamClient(getSyncProtocolExecutorService(),configuration);
+        return transportConfiguration.createStreamClient(getSyncProtocolExecutorService(), configuration);
     }
 
     @Override

--- a/bundles/org.jupnp/src/main/java/org/jupnp/DefaultUpnpServiceConfiguration.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/DefaultUpnpServiceConfiguration.java
@@ -51,6 +51,7 @@ import org.jupnp.transport.spi.MulticastReceiver;
 import org.jupnp.transport.spi.NetworkAddressFactory;
 import org.jupnp.transport.spi.SOAPActionProcessor;
 import org.jupnp.transport.spi.StreamClient;
+import org.jupnp.transport.spi.StreamClientConfiguration;
 import org.jupnp.transport.spi.StreamServer;
 import org.jupnp.util.Exceptions;
 
@@ -110,6 +111,7 @@ public class DefaultUpnpServiceConfiguration implements UpnpServiceConfiguration
     final private ServiceDescriptorBinder serviceDescriptorBinderUDA10;
 
     final private Namespace namespace;
+    private StreamClientConfiguration configuration;
 
     @SuppressWarnings("rawtypes")
     final private TransportConfiguration transportConfiguration;
@@ -173,7 +175,7 @@ public class DefaultUpnpServiceConfiguration implements UpnpServiceConfiguration
     @Override
     @SuppressWarnings("rawtypes")
     public StreamClient createStreamClient() {
-        return transportConfiguration.createStreamClient(getSyncProtocolExecutorService());
+        return transportConfiguration.createStreamClient(getSyncProtocolExecutorService(),configuration);
     }
 
     @Override

--- a/bundles/org.jupnp/src/main/java/org/jupnp/OSGiUpnpServiceConfiguration.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/OSGiUpnpServiceConfiguration.java
@@ -48,6 +48,7 @@ import org.jupnp.transport.spi.MulticastReceiver;
 import org.jupnp.transport.spi.NetworkAddressFactory;
 import org.jupnp.transport.spi.SOAPActionProcessor;
 import org.jupnp.transport.spi.StreamClient;
+import org.jupnp.transport.spi.StreamClientConfiguration;
 import org.jupnp.transport.spi.StreamServer;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.ServiceReference;
@@ -90,6 +91,7 @@ public class OSGiUpnpServiceConfiguration implements UpnpServiceConfiguration {
     private int httpProxyPort = -1;
     private int streamListenPort = 8080;
     private Namespace callbackURI = new Namespace("http://localhost/upnpcallback");
+    private StreamClientConfiguration configuration;
 
     private ExecutorService mainExecutorService;
     private ExecutorService asyncExecutorService;
@@ -193,7 +195,7 @@ public class OSGiUpnpServiceConfiguration implements UpnpServiceConfiguration {
     @Override
     @SuppressWarnings("rawtypes")
     public StreamClient createStreamClient() {
-        return transportConfiguration.createStreamClient(getSyncProtocolExecutorService());
+        return transportConfiguration.createStreamClient(getSyncProtocolExecutorService(),configuration);
     }
 
     @Override

--- a/bundles/org.jupnp/src/main/java/org/jupnp/OSGiUpnpServiceConfiguration.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/OSGiUpnpServiceConfiguration.java
@@ -195,7 +195,7 @@ public class OSGiUpnpServiceConfiguration implements UpnpServiceConfiguration {
     @Override
     @SuppressWarnings("rawtypes")
     public StreamClient createStreamClient() {
-        return transportConfiguration.createStreamClient(getSyncProtocolExecutorService(),configuration);
+        return transportConfiguration.createStreamClient(getSyncProtocolExecutorService(), configuration);
     }
 
     @Override

--- a/bundles/org.jupnp/src/main/java/org/jupnp/transport/TransportConfiguration.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/transport/TransportConfiguration.java
@@ -37,7 +37,7 @@ public interface TransportConfiguration<SCC extends StreamClientConfiguration, S
      * @param executorService used to dispatch request/response processing.
      * @return created {@link StreamClient}
      */
-    StreamClient<SCC> createStreamClient(final ExecutorService executorService);
+    StreamClient<SCC> createStreamClient(final ExecutorService executorService, final StreamClientConfiguration configuration);
 
     /**
      * Creates a {@link StreamServer} using the given {@code listenerPort}.

--- a/bundles/org.jupnp/src/main/java/org/jupnp/transport/impl/jetty/JettyTransportConfiguration.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/transport/impl/jetty/JettyTransportConfiguration.java
@@ -6,6 +6,7 @@ import org.jupnp.transport.TransportConfiguration;
 import org.jupnp.transport.impl.ServletStreamServerConfigurationImpl;
 import org.jupnp.transport.impl.ServletStreamServerImpl;
 import org.jupnp.transport.spi.StreamClient;
+import org.jupnp.transport.spi.StreamClientConfiguration;
 import org.jupnp.transport.spi.StreamServer;
 
 /**
@@ -19,7 +20,7 @@ public class JettyTransportConfiguration
     public static final TransportConfiguration INSTANCE = new JettyTransportConfiguration();
 
     @Override
-    public StreamClient createStreamClient(final ExecutorService executorService) {
+    public StreamClient createStreamClient(final ExecutorService executorService, final StreamClientConfiguration configuration) {
         return new JettyStreamClientImpl(
                 new StreamClientConfigurationImpl(
                         executorService

--- a/tests/core/src/test/java/org/jupnp/test/transport/JettyServerJettyClientTest.java
+++ b/tests/core/src/test/java/org/jupnp/test/transport/JettyServerJettyClientTest.java
@@ -19,6 +19,7 @@ import org.jupnp.test.transport.StreamServerClientTest;
 import org.jupnp.transport.TransportConfiguration;
 import org.jupnp.transport.impl.jetty.JettyTransportConfiguration;
 import org.jupnp.transport.spi.StreamClient;
+import org.jupnp.transport.spi.StreamClientConfiguration;
 import org.jupnp.transport.spi.StreamServer;
 
 /**
@@ -28,6 +29,7 @@ import org.jupnp.transport.spi.StreamServer;
 public class JettyServerJettyClientTest extends StreamServerClientTest {
 
     private TransportConfiguration jettyTransportConfiguration = JettyTransportConfiguration.INSTANCE;
+    private StreamClientConfiguration sccConfiguration;
 
     @Override
     public StreamServer createStreamServer(final int port) {
@@ -37,7 +39,7 @@ public class JettyServerJettyClientTest extends StreamServerClientTest {
     @Override
     public StreamClient createStreamClient(UpnpServiceConfiguration configuration) {
         return jettyTransportConfiguration.createStreamClient(
-                configuration.getSyncProtocolExecutorService()
+                configuration.getSyncProtocolExecutorService(),sccConfiguration
         );
     }
 

--- a/tests/core/src/test/java/org/jupnp/test/transport/JettyServerJettyClientTest.java
+++ b/tests/core/src/test/java/org/jupnp/test/transport/JettyServerJettyClientTest.java
@@ -39,7 +39,7 @@ public class JettyServerJettyClientTest extends StreamServerClientTest {
     @Override
     public StreamClient createStreamClient(UpnpServiceConfiguration configuration) {
         return jettyTransportConfiguration.createStreamClient(
-                configuration.getSyncProtocolExecutorService(),sccConfiguration
+                configuration.getSyncProtocolExecutorService(), sccConfiguration
         );
     }
 

--- a/tests/devices/simple/META-INF/MANIFEST.MF
+++ b/tests/devices/simple/META-INF/MANIFEST.MF
@@ -1,27 +1,27 @@
 Manifest-Version: 1.0
-Bundle-Description: A test device that exposes all the capablities of 
- OSGi UPnP.
-Bundle-License: http://opensource.org/licenses/CDDL-1.0
-Bundle-SymbolicName: org.jupnp.osgi.upnp.test.device.simple
-Built-By: A11202833
 Bundle-ManifestVersion: 2
-Bnd-LastModified: 1601123198318
-Embed-Dependency: jupnp-osgi-tests-common,commons-codec
+Created-By: Apache Maven Bundle Plugin
+Tool: Bnd-1.15.0
+Bnd-LastModified: 1616622889009
+Import-Package: org.osgi.framework;version="[1.5,2)",org.osgi.service.de
+ vice;version="[1.1,2)",org.osgi.service.event;version="[1.2,2)",org.osg
+ i.service.upnp;version="[1.1,2)",org.osgi.util.tracker;version="[1.4,2)
+ ",org.slf4j;version="[1.7,2)"
+Bundle-ClassPath: .,jupnp-osgi-tests-common-2.6.0-SNAPSHOT.jar,commons-c
+ odec-1.4.jar
+Embed-Transitive: false
+Bundle-Version: 2.6.0.SNAPSHOT
+Bundle-SymbolicName: org.jupnp.osgi.upnp.test.device.simple
+Bundle-License: http://opensource.org/licenses/CDDL-1.0
 SymbolicName: org.jupnp.osgi.upnp.test.device.simple
 Bundle-DocURL: http://www.jupnp.org
-Bundle-Vendor: jUPnP.org
-Import-Package: org.osgi.framework;version="[1.5,2)",org.osgi.service.
- device;version="[1.1,2)",org.osgi.service.event;version="[1.2,2)",org
- .osgi.service.upnp;version="[1.1,2)",org.osgi.util.tracker;version="[
- 1.4,2)",org.slf4j;version="[1.7,2)"
-Tool: Bnd-1.15.0
-Bundle-Version: 2.6.0.SNAPSHOT
-Bundle-Name: jUPnP OSGi Test Simple Device
-Bundle-ClassPath: .,jupnp-osgi-tests-common-2.6.0-SNAPSHOT.jar,commons
- -codec-1.4.jar
-Bundle-Activator: org.jupnp.osgi.upnp.test.device.simple.Activator
-Embed-Transitive: false
-Created-By: Apache Maven Bundle Plugin
-Build-Jdk: 1.8.0_231
+Bundle-Description: A test device that exposes all the capablities of OS
+ Gi UPnP.
 Bundle-Author: Bruce Green
+Bundle-Activator: org.jupnp.osgi.upnp.test.device.simple.Activator
+Embed-Dependency: jupnp-osgi-tests-common,commons-codec
+Bundle-Vendor: jUPnP.org
+Bundle-Name: jUPnP OSGi Test Simple Device
+Built-By: openhab
+Build-Jdk: 11.0.10
 

--- a/tests/devices/simple/META-INF/MANIFEST.MF
+++ b/tests/devices/simple/META-INF/MANIFEST.MF
@@ -1,27 +1,27 @@
 Manifest-Version: 1.0
-Bundle-ManifestVersion: 2
-Created-By: Apache Maven Bundle Plugin
-Tool: Bnd-1.15.0
-Bnd-LastModified: 1616622889009
-Import-Package: org.osgi.framework;version="[1.5,2)",org.osgi.service.de
- vice;version="[1.1,2)",org.osgi.service.event;version="[1.2,2)",org.osg
- i.service.upnp;version="[1.1,2)",org.osgi.util.tracker;version="[1.4,2)
- ",org.slf4j;version="[1.7,2)"
-Bundle-ClassPath: .,jupnp-osgi-tests-common-2.6.0-SNAPSHOT.jar,commons-c
- odec-1.4.jar
-Embed-Transitive: false
-Bundle-Version: 2.6.0.SNAPSHOT
-Bundle-SymbolicName: org.jupnp.osgi.upnp.test.device.simple
+Bundle-Description: A test device that exposes all the capablities of 
+ OSGi UPnP.
 Bundle-License: http://opensource.org/licenses/CDDL-1.0
+Bundle-SymbolicName: org.jupnp.osgi.upnp.test.device.simple
+Built-By: A11202833
+Bundle-ManifestVersion: 2
+Bnd-LastModified: 1601123198318
+Embed-Dependency: jupnp-osgi-tests-common,commons-codec
 SymbolicName: org.jupnp.osgi.upnp.test.device.simple
 Bundle-DocURL: http://www.jupnp.org
-Bundle-Description: A test device that exposes all the capablities of OS
- Gi UPnP.
-Bundle-Author: Bruce Green
-Bundle-Activator: org.jupnp.osgi.upnp.test.device.simple.Activator
-Embed-Dependency: jupnp-osgi-tests-common,commons-codec
 Bundle-Vendor: jUPnP.org
+Import-Package: org.osgi.framework;version="[1.5,2)",org.osgi.service.
+ device;version="[1.1,2)",org.osgi.service.event;version="[1.2,2)",org
+ .osgi.service.upnp;version="[1.1,2)",org.osgi.util.tracker;version="[
+ 1.4,2)",org.slf4j;version="[1.7,2)"
+Tool: Bnd-1.15.0
+Bundle-Version: 2.6.0.SNAPSHOT
 Bundle-Name: jUPnP OSGi Test Simple Device
-Built-By: openhab
-Build-Jdk: 11.0.10
+Bundle-ClassPath: .,jupnp-osgi-tests-common-2.6.0-SNAPSHOT.jar,commons
+ -codec-1.4.jar
+Bundle-Activator: org.jupnp.osgi.upnp.test.device.simple.Activator
+Embed-Transitive: false
+Created-By: Apache Maven Bundle Plugin
+Build-Jdk: 1.8.0_231
+Bundle-Author: Bruce Green
 

--- a/tools/org.jupnp.tool/src/main/java/org/jupnp/tool/cli/CmdlineUPnPServiceConfiguration.java
+++ b/tools/org.jupnp.tool/src/main/java/org/jupnp/tool/cli/CmdlineUPnPServiceConfiguration.java
@@ -26,6 +26,7 @@ import org.jupnp.transport.TransportConfiguration;
 import org.jupnp.transport.impl.NetworkAddressFactoryImpl;
 import org.jupnp.transport.spi.NetworkAddressFactory;
 import org.jupnp.transport.spi.StreamClient;
+import org.jupnp.transport.spi.StreamClientConfiguration;
 import org.jupnp.transport.spi.StreamServer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -69,6 +70,8 @@ public class CmdlineUPnPServiceConfiguration extends DefaultUpnpServiceConfigura
     private ExecutorService asyncExecutorService;
 
     private TransportConfiguration transportConfiguration;
+
+        private StreamClientConfiguration configuration;
 
 	// instance methods
 
@@ -149,7 +152,7 @@ public class CmdlineUPnPServiceConfiguration extends DefaultUpnpServiceConfigura
     @Override
     public StreamClient createStreamClient() {
         return transportConfiguration.createStreamClient(
-                getSyncProtocolExecutorService()
+                getSyncProtocolExecutorService(),configuration
         );
     }
 

--- a/tools/org.jupnp.tool/src/main/java/org/jupnp/tool/cli/CmdlineUPnPServiceConfiguration.java
+++ b/tools/org.jupnp.tool/src/main/java/org/jupnp/tool/cli/CmdlineUPnPServiceConfiguration.java
@@ -152,7 +152,7 @@ public class CmdlineUPnPServiceConfiguration extends DefaultUpnpServiceConfigura
     @Override
     public StreamClient createStreamClient() {
         return transportConfiguration.createStreamClient(
-                getSyncProtocolExecutorService(),configuration
+                getSyncProtocolExecutorService(), configuration
         );
     }
 

--- a/tools/org.jupnp.tool/src/main/java/org/jupnp/tool/cli/CmdlineUPnPServiceConfiguration.java
+++ b/tools/org.jupnp.tool/src/main/java/org/jupnp/tool/cli/CmdlineUPnPServiceConfiguration.java
@@ -71,7 +71,7 @@ public class CmdlineUPnPServiceConfiguration extends DefaultUpnpServiceConfigura
 
     private TransportConfiguration transportConfiguration;
 
-        private StreamClientConfiguration configuration;
+    private StreamClientConfiguration configuration;
 
 	// instance methods
 

--- a/tools/org.jupnp.tool/src/main/java/org/jupnp/tool/transport/JDKTransportConfiguration.java
+++ b/tools/org.jupnp.tool/src/main/java/org/jupnp/tool/transport/JDKTransportConfiguration.java
@@ -4,6 +4,7 @@ import java.util.concurrent.ExecutorService;
 
 import org.jupnp.transport.TransportConfiguration;
 import org.jupnp.transport.spi.StreamClient;
+import org.jupnp.transport.spi.StreamClientConfiguration;
 import org.jupnp.transport.spi.StreamServer;
 
 /**
@@ -15,9 +16,10 @@ public class JDKTransportConfiguration
     implements TransportConfiguration {
 
     public static final TransportConfiguration INSTANCE = new JDKTransportConfiguration();
+    private StreamClientConfiguration configuration;
 
     @Override
-    public StreamClient createStreamClient(final ExecutorService executorService) {
+    public StreamClient createStreamClient(final ExecutorService executorService, final StreamClientConfiguration configuration) {
         return new StreamClientImpl(
                 new StreamClientConfigurationImpl(
                         executorService


### PR DESCRIPTION
Adds StreamClientConfiguration to createStreamClient 

This allows the passing of different configuration variables without having to make changes in so many places when one is added.