### PR TITLE
Set async support init param

### DIFF
--- a/bundles/org.jupnp/src/main/java/org/jupnp/transport/impl/osgi/HttpServiceServletContainerAdapter.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/transport/impl/osgi/HttpServiceServletContainerAdapter.java
@@ -22,6 +22,7 @@ import java.util.concurrent.ExecutorService;
 import javax.servlet.Servlet;
 import javax.servlet.ServletException;
 
+import org.jupnp.transport.impl.async.AsyncServlet;
 import org.jupnp.transport.spi.ServletContainerAdapter;
 import org.osgi.framework.BundleContext;
 import org.osgi.service.http.HttpService;
@@ -77,9 +78,12 @@ public class HttpServiceServletContainerAdapter implements
 	@Override
 	public void registerServlet(String contextPath, Servlet servlet) {
         if (this.contextPath == null) {
-            Dictionary<?, ?> params = new Properties();
+            Dictionary<Object, Object> params = new Properties();
             try {
                 logger.info("Registering UPnP callback servlet as {}", contextPath);
+                if (servlet instanceof AsyncServlet) {
+                    params.put("async-supported", "true");
+                }
                 httpService.registerServlet(contextPath, servlet, params, new DisableAuthenticationHttpContext());
                 this.contextPath = contextPath;
             } catch (ServletException | NamespaceException | IllegalStateException e) {


### PR DESCRIPTION
When using jupnp with Karaf 4.4.3, Jetty 9.4.50.v20221201 and Pax Web 8.0.15 the following exceptions are thrown:

```
2023-03-03 21:08:09.924 [WARN ] [org.eclipse.jetty.server.HttpChannel] - /upnpcallback/dev/RINCON_000xxxxxxx/svc/upnp-org/DeviceProperties/event/cb
java.lang.IllegalStateException: !asyncSupported: NotAsync:org.ops4j.pax.web.service.spi.servlet.OsgiInitializedServlet@1a1464b
        at org.eclipse.jetty.server.Request.startAsync(Request.java:2338) ~[?:?]
        at javax.servlet.ServletRequestWrapper.startAsync(ServletRequestWrapper.java:363) ~[bundleFile:4.0.4]
        at org.jupnp.transport.impl.async.AsyncServlet.service(AsyncServlet.java:68) ~[?:?]
        at javax.servlet.http.HttpServlet.service(HttpServlet.java:584) ~[bundleFile:4.0.4]
        at org.ops4j.pax.web.service.spi.servlet.OsgiInitializedServlet.service(OsgiInitializedServlet.java:102) ~[?:?]
        at org.eclipse.jetty.servlet.ServletHolder$NotAsync.service(ServletHolder.java:1450) ~[?:?]
        at org.eclipse.jetty.servlet.ServletHolder.handle(ServletHolder.java:799) ~[?:?]
        at org.eclipse.jetty.servlet.ServletHandler$ChainEnd.doFilter(ServletHandler.java:1656) ~[?:?]
        at org.ops4j.pax.web.service.spi.servlet.OsgiFilterChain.doFilter(OsgiFilterChain.java:100) ~[?:?]
        at org.ops4j.pax.web.service.jetty.internal.PaxWebServletHandler.doHandle(PaxWebServletHandler.java:310) ~[?:?]
        at org.eclipse.jetty.server.handler.ScopedHandler.handle(ScopedHandler.java:143) ~[?:?]
        at org.eclipse.jetty.security.SecurityHandler.handle(SecurityHandler.java:600) ~[?:?]
        at org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:127) ~[?:?]
        at org.eclipse.jetty.server.handler.ScopedHandler.nextHandle(ScopedHandler.java:235) ~[?:?]
        at org.eclipse.jetty.server.session.SessionHandler.doHandle(SessionHandler.java:1624) ~[?:?]
        at org.eclipse.jetty.server.handler.ScopedHandler.nextHandle(ScopedHandler.java:233) ~[?:?]
        at org.eclipse.jetty.server.handler.ContextHandler.doHandle(ContextHandler.java:1440) ~[?:?]
        at org.eclipse.jetty.server.handler.ScopedHandler.nextScope(ScopedHandler.java:188) ~[?:?]
        at org.eclipse.jetty.servlet.ServletHandler.doScope(ServletHandler.java:505) ~[?:?]
        at org.eclipse.jetty.server.session.SessionHandler.doScope(SessionHandler.java:1594) ~[?:?]
        at org.eclipse.jetty.server.handler.ScopedHandler.nextScope(ScopedHandler.java:186) ~[?:?]
        at org.eclipse.jetty.server.handler.ContextHandler.doScope(ContextHandler.java:1355) ~[?:?]
        at org.eclipse.jetty.server.handler.ScopedHandler.handle(ScopedHandler.java:141) ~[?:?]
        at org.eclipse.jetty.server.handler.ContextHandlerCollection.handle(ContextHandlerCollection.java:234) ~[?:?]
        at org.ops4j.pax.web.service.jetty.internal.PrioritizedHandlerCollection.handle(PrioritizedHandlerCollection.java:96) ~[?:?]
        at org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:127) ~[?:?]
        at org.eclipse.jetty.server.Server.handle(Server.java:516) ~[?:?]
        at org.eclipse.jetty.server.HttpChannel.lambda$handle$1(HttpChannel.java:487) ~[?:?]
        at org.eclipse.jetty.server.HttpChannel.dispatch(HttpChannel.java:732) ~[?:?]
        at org.eclipse.jetty.server.HttpChannel.handle(HttpChannel.java:479) ~[?:?]
        at org.eclipse.jetty.server.HttpConnection.onFillable(HttpConnection.java:277) ~[?:?]
        at org.eclipse.jetty.io.AbstractConnection$ReadCallback.succeeded(AbstractConnection.java:311) ~[?:?]
        at org.eclipse.jetty.io.FillInterest.fillable(FillInterest.java:105) ~[?:?]
        at org.eclipse.jetty.io.ChannelEndPoint$1.run(ChannelEndPoint.java:104) ~[?:?]
        at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.runTask(EatWhatYouKill.java:338) ~[bundleFile:9.4.50.v20221201]
        at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.doProduce(EatWhatYouKill.java:315) ~[bundleFile:9.4.50.v20221201]
        at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.tryProduce(EatWhatYouKill.java:173) ~[bundleFile:9.4.50.v20221201]
        at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.run(EatWhatYouKill.java:131) ~[bundleFile:9.4.50.v20221201]
        at org.eclipse.jetty.util.thread.ReservedThreadExecutor$ReservedThread.run(ReservedThreadExecutor.java:409) ~[bundleFile:9.4.50.v20221201]
        at org.eclipse.jetty.util.thread.QueuedThreadPool.runJob(QueuedThreadPool.java:883) ~[bundleFile:9.4.50.v20221201]
        at org.eclipse.jetty.util.thread.QueuedThreadPool$Runner.run(QueuedThreadPool.java:1034) ~[bundleFile:9.4.50.v20221201]
        at java.lang.Thread.run(Unknown Source) ~[?:?]
```

This PR fixes this by setting the "async-supported" Servlet init param to "true" when registering `AsyncServlet`s using the `HttpService`.

See also:

* https://github.com/openhab/openhab-distro/issues/1473
* https://groups.google.com/g/ops4j/c/E9p7tPydPmo
* https://github.com/ops4j/org.ops4j.pax.web/issues/1767