### PR TITLE
Update testng, surefire, compiler

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
         <tycho-version>1.2.0</tycho-version>
         <tycho-groupid>org.eclipse.tycho</tycho-groupid>
 
-        <testng.version>6.2</testng.version>
+        <testng.version>6.14.3</testng.version>
         <jetty.version>9.3.14.v20161028</jetty.version>
         <servlet.api.version>2.5</servlet.api.version>
         <slf4j.version>1.7.2</slf4j.version>
@@ -92,7 +92,7 @@
                 <!-- Unit tests -->
                 <plugin>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>2.9</version>
+                    <version>2.22.2</version>
                     <configuration>
                         <redirectTestOutputToFile>true</redirectTestOutputToFile>
                     </configuration>
@@ -125,7 +125,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.0</version>
+                    <version>3.11.0</version>
                     <configuration>
                         <compilerArgs>
                             <arg>-XDignore.symbol.file</arg>
@@ -183,7 +183,6 @@
     </build>
 
     <dependencies>
-
         <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>


### PR DESCRIPTION
Fixes exceptions:

```
Running org.jupnp.tool.cli.SearchCommandTest
##[error]Exception in thread "ThreadedStreamConsumer" java.lang.NoSuchMethodError: org.apache.maven.surefire.report.StackTraceWriter.getThrowable()Ljava/lang/Throwable;
	at org.apache.maven.surefire.report.XMLReporter.writeTestProblems(XMLReporter.java:238)
	at org.apache.maven.surefire.report.XMLReporter.testFailed(XMLReporter.java:215)
	at org.apache.maven.surefire.report.MulticastingReporter.testFailed(MulticastingReporter.java:80)
	at org.apache.maven.surefire.report.TestSetRunListener.testFailed(TestSetRunListener.java:157)
	at org.apache.maven.plugin.surefire.booterclient.output.ForkClient.consumeLine(ForkClient.java:106)
	at org.apache.maven.plugin.surefire.booterclient.output.ThreadedStreamConsumer$Pumper.run(ThreadedStreamConsumer.java:67)
	at java.lang.Thread.run(Thread.java:750)
```

Fixes unknown plugin config options:

```
[WARNING] Parameter 'compilerArgs' is unknown for plugin 'maven-compiler-plugin:3.0:compile (default-compile)'
[WARNING] Parameter 'compilerArgs' is unknown for plugin 'maven-compiler-plugin:3.0:testCompile (default-testCompile)'
```

The updates also result in line numbers being added of failed assertions during tests so they can be more easily fixed.