### PR TITLE
Replace java.util.logging with SLF4J

### DIFF
--- a/bundles/org.jupnp.support/src/main/java/org/jupnp/support/avtransport/callback/Next.java
+++ b/bundles/org.jupnp.support/src/main/java/org/jupnp/support/avtransport/callback/Next.java
@@ -20,8 +20,8 @@ import org.jupnp.controlpoint.ControlPoint;
 import org.jupnp.model.action.ActionInvocation;
 import org.jupnp.model.meta.Service;
 import org.jupnp.model.types.UnsignedIntegerFourBytes;
-
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * @author Christian Bauer - Initial Contribution
@@ -29,7 +29,7 @@ import java.util.logging.Logger;
  */
 public abstract class Next extends ActionCallback {
 
-    private final Logger logger = Logger.getLogger(Next.class.getName());
+    private final Logger logger = LoggerFactory.getLogger(Next.class);
 
     protected Next(ActionInvocation<?> actionInvocation, ControlPoint controlPoint) {
         super(actionInvocation, controlPoint);
@@ -50,6 +50,6 @@ public abstract class Next extends ActionCallback {
 
     @Override
     public void success(ActionInvocation invocation) {
-        logger.fine("Execution successful");
+        logger.debug("Execution successful");
     }
 }

--- a/bundles/org.jupnp.support/src/main/java/org/jupnp/support/avtransport/callback/Pause.java
+++ b/bundles/org.jupnp.support/src/main/java/org/jupnp/support/avtransport/callback/Pause.java
@@ -20,8 +20,8 @@ import org.jupnp.controlpoint.ControlPoint;
 import org.jupnp.model.action.ActionInvocation;
 import org.jupnp.model.meta.Service;
 import org.jupnp.model.types.UnsignedIntegerFourBytes;
-
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * @author Christian Bauer - Initial Contribution
@@ -29,7 +29,7 @@ import java.util.logging.Logger;
  */
 public abstract class Pause extends ActionCallback {
 
-    private final Logger logger = Logger.getLogger(Pause.class.getName());
+    private final Logger logger = LoggerFactory.getLogger(Pause.class);
 
     protected Pause(ActionInvocation<?> actionInvocation, ControlPoint controlPoint) {
         super(actionInvocation, controlPoint);
@@ -50,6 +50,6 @@ public abstract class Pause extends ActionCallback {
 
     @Override
     public void success(ActionInvocation invocation) {
-        logger.fine("Execution successful");
+        logger.debug("Execution successful");
     }
 }

--- a/bundles/org.jupnp.support/src/main/java/org/jupnp/support/avtransport/callback/Play.java
+++ b/bundles/org.jupnp.support/src/main/java/org/jupnp/support/avtransport/callback/Play.java
@@ -19,8 +19,8 @@ import org.jupnp.controlpoint.ActionCallback;
 import org.jupnp.model.action.ActionInvocation;
 import org.jupnp.model.meta.Service;
 import org.jupnp.model.types.UnsignedIntegerFourBytes;
-
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * @author Christian Bauer - Initial Contribution
@@ -28,7 +28,7 @@ import java.util.logging.Logger;
  */
 public abstract class Play extends ActionCallback {
 
-    private final Logger logger = Logger.getLogger(Play.class.getName());
+    private final Logger logger = LoggerFactory.getLogger(Play.class);
 
     public Play(Service<?, ?> service) {
         this(new UnsignedIntegerFourBytes(0), service, "1");
@@ -50,6 +50,6 @@ public abstract class Play extends ActionCallback {
 
     @Override
     public void success(ActionInvocation invocation) {
-        logger.fine("Execution successful");
+        logger.debug("Execution successful");
     }
 }

--- a/bundles/org.jupnp.support/src/main/java/org/jupnp/support/avtransport/callback/Previous.java
+++ b/bundles/org.jupnp.support/src/main/java/org/jupnp/support/avtransport/callback/Previous.java
@@ -20,8 +20,8 @@ import org.jupnp.controlpoint.ControlPoint;
 import org.jupnp.model.action.ActionInvocation;
 import org.jupnp.model.meta.Service;
 import org.jupnp.model.types.UnsignedIntegerFourBytes;
-
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * @author Christian Bauer - Initial Contribution
@@ -29,7 +29,7 @@ import java.util.logging.Logger;
  */
 public abstract class Previous extends ActionCallback {
 
-    private final Logger logger = Logger.getLogger(Previous.class.getName());
+    private final Logger logger = LoggerFactory.getLogger(Previous.class);
 
     protected Previous(ActionInvocation<?> actionInvocation, ControlPoint controlPoint) {
         super(actionInvocation, controlPoint);
@@ -50,6 +50,6 @@ public abstract class Previous extends ActionCallback {
 
     @Override
     public void success(ActionInvocation invocation) {
-        logger.fine("Execution successful");
+        logger.debug("Execution successful");
     }
 }

--- a/bundles/org.jupnp.support/src/main/java/org/jupnp/support/avtransport/callback/Seek.java
+++ b/bundles/org.jupnp.support/src/main/java/org/jupnp/support/avtransport/callback/Seek.java
@@ -20,8 +20,8 @@ import org.jupnp.model.action.ActionInvocation;
 import org.jupnp.model.meta.Service;
 import org.jupnp.model.types.UnsignedIntegerFourBytes;
 import org.jupnp.support.model.SeekMode;
-
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * @author Christian Bauer - Initial Contribution
@@ -29,7 +29,7 @@ import java.util.logging.Logger;
  */
 public abstract class Seek extends ActionCallback {
 
-    private final Logger logger = Logger.getLogger(Seek.class.getName());
+    private final Logger logger = LoggerFactory.getLogger(Seek.class);
 
     public Seek(Service<?, ?> service, String relativeTimeTarget) {
         this(new UnsignedIntegerFourBytes(0), service, SeekMode.REL_TIME, relativeTimeTarget);
@@ -52,6 +52,6 @@ public abstract class Seek extends ActionCallback {
 
     @Override
     public void success(ActionInvocation invocation) {
-        logger.fine("Execution successful");
+        logger.debug("Execution successful");
     }
 }

--- a/bundles/org.jupnp.support/src/main/java/org/jupnp/support/avtransport/callback/SetAVTransportURI.java
+++ b/bundles/org.jupnp.support/src/main/java/org/jupnp/support/avtransport/callback/SetAVTransportURI.java
@@ -19,8 +19,8 @@ import org.jupnp.controlpoint.ActionCallback;
 import org.jupnp.model.action.ActionInvocation;
 import org.jupnp.model.meta.Service;
 import org.jupnp.model.types.UnsignedIntegerFourBytes;
-
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * @author Christian Bauer - Initial Contribution
@@ -28,7 +28,7 @@ import java.util.logging.Logger;
  */
 public abstract class SetAVTransportURI extends ActionCallback {
 
-    private final Logger logger = Logger.getLogger(SetAVTransportURI.class.getName());
+    private final Logger logger = LoggerFactory.getLogger(SetAVTransportURI.class);
 
     public SetAVTransportURI(Service<?, ?> service, String uri) {
         this(new UnsignedIntegerFourBytes(0), service, uri, null);
@@ -44,7 +44,7 @@ public abstract class SetAVTransportURI extends ActionCallback {
 
     public SetAVTransportURI(UnsignedIntegerFourBytes instanceId, Service<?, ?> service, String uri, String metadata) {
         super(new ActionInvocation<>(service.getAction("SetAVTransportURI")));
-        logger.fine("Creating SetAVTransportURI action for URI: " + uri);
+        logger.debug("Creating SetAVTransportURI action for URI: {}", uri);
         getActionInvocation().setInput("InstanceID", instanceId);
         getActionInvocation().setInput("CurrentURI", uri);
         getActionInvocation().setInput("CurrentURIMetaData", metadata);
@@ -52,6 +52,6 @@ public abstract class SetAVTransportURI extends ActionCallback {
 
     @Override
     public void success(ActionInvocation invocation) {
-        logger.fine("Execution successful");
+        logger.debug("Execution successful");
     }
 }

--- a/bundles/org.jupnp.support/src/main/java/org/jupnp/support/avtransport/callback/SetPlayMode.java
+++ b/bundles/org.jupnp.support/src/main/java/org/jupnp/support/avtransport/callback/SetPlayMode.java
@@ -20,8 +20,8 @@ import org.jupnp.model.action.ActionInvocation;
 import org.jupnp.model.meta.Service;
 import org.jupnp.model.types.UnsignedIntegerFourBytes;
 import org.jupnp.support.model.PlayMode;
-
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * @author Christian Bauer - Initial Contribution
@@ -29,7 +29,7 @@ import java.util.logging.Logger;
  */
 public abstract class SetPlayMode extends ActionCallback {
 
-    private final Logger logger = Logger.getLogger(SetPlayMode.class.getName());
+    private final Logger logger = LoggerFactory.getLogger(SetPlayMode.class);
 
     public SetPlayMode(Service<?, ?> service, PlayMode playMode) {
         this(new UnsignedIntegerFourBytes(0), service, playMode);
@@ -43,6 +43,6 @@ public abstract class SetPlayMode extends ActionCallback {
 
     @Override
     public void success(ActionInvocation invocation) {
-        logger.fine("Execution successful");
+        logger.debug("Execution successful");
     }
 }

--- a/bundles/org.jupnp.support/src/main/java/org/jupnp/support/avtransport/callback/Stop.java
+++ b/bundles/org.jupnp.support/src/main/java/org/jupnp/support/avtransport/callback/Stop.java
@@ -19,8 +19,8 @@ import org.jupnp.controlpoint.ActionCallback;
 import org.jupnp.model.action.ActionInvocation;
 import org.jupnp.model.meta.Service;
 import org.jupnp.model.types.UnsignedIntegerFourBytes;
-
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * @author Christian Bauer - Initial Contribution
@@ -28,7 +28,7 @@ import java.util.logging.Logger;
  */
 public abstract class Stop extends ActionCallback {
 
-    private static Logger logger = Logger.getLogger(Stop.class.getName());
+    private final Logger logger = LoggerFactory.getLogger(Stop.class);
 
     public Stop(Service<?, ?> service) {
         this(new UnsignedIntegerFourBytes(0), service);
@@ -41,6 +41,6 @@ public abstract class Stop extends ActionCallback {
 
     @Override
     public void success(ActionInvocation invocation) {
-        logger.fine("Execution successful");
+        logger.debug("Execution successful");
     }
 }

--- a/bundles/org.jupnp.support/src/main/java/org/jupnp/support/avtransport/impl/AVTransportService.java
+++ b/bundles/org.jupnp.support/src/main/java/org/jupnp/support/avtransport/impl/AVTransportService.java
@@ -18,7 +18,6 @@ package org.jupnp.support.avtransport.impl;
 import java.net.URI;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.logging.Logger;
 
 import org.jupnp.model.types.ErrorCode;
 import org.jupnp.model.types.UnsignedIntegerFourBytes;
@@ -40,6 +39,8 @@ import org.jupnp.support.model.TransportInfo;
 import org.jupnp.support.model.TransportSettings;
 import org.jupnp.util.statemachine.StateMachineBuilder;
 import org.jupnp.util.statemachine.TransitionException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * State-machine based implementation of AVTransport service.
@@ -79,7 +80,7 @@ import org.jupnp.util.statemachine.TransitionException;
  */
 public class AVTransportService<T extends AVTransport> extends AbstractAVTransportService {
 
-    private final Logger logger = Logger.getLogger(AVTransportService.class.getName());
+    private final Logger logger = LoggerFactory.getLogger(AVTransportService.class);
 
     private final Map<Long, AVTransportStateMachine> stateMachines = new ConcurrentHashMap<>();
 
@@ -292,13 +293,13 @@ public class AVTransportService<T extends AVTransport> extends AbstractAVTranspo
             long id = instanceId.getValue();
             AVTransportStateMachine stateMachine = stateMachines.get(id);
             if (stateMachine == null && id == 0 && createDefaultTransport) {
-                logger.fine("Creating default transport instance with ID '0'");
+                logger.debug("Creating default transport instance with ID '0'");
                 stateMachine = createStateMachine(instanceId);
                 stateMachines.put(id, stateMachine);
             } else if (stateMachine == null) {
                 throw new AVTransportException(AVTransportErrorCode.INVALID_INSTANCE_ID);
             }
-            logger.fine("Found transport control with ID '" + id + "'");
+            logger.debug("Found transport control with ID '{}'", id);
             return stateMachine;
         }
     }

--- a/bundles/org.jupnp.support/src/main/java/org/jupnp/support/avtransport/impl/state/NoMediaPresent.java
+++ b/bundles/org.jupnp.support/src/main/java/org/jupnp/support/avtransport/impl/state/NoMediaPresent.java
@@ -20,9 +20,10 @@ import org.jupnp.support.model.AVTransport;
 import org.jupnp.support.model.TransportAction;
 import org.jupnp.support.model.TransportInfo;
 import org.jupnp.support.model.TransportState;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.net.URI;
-import java.util.logging.Logger;
 
 /**
  * @author Christian Bauer - Initial Contribution
@@ -30,14 +31,14 @@ import java.util.logging.Logger;
  */
 public abstract class NoMediaPresent<T extends AVTransport> extends AbstractState<T> {
 
-    private final Logger logger = Logger.getLogger(NoMediaPresent.class.getName());
+    private final Logger logger = LoggerFactory.getLogger(NoMediaPresent.class);
 
     public NoMediaPresent(T transport) {
         super(transport);
     }
 
     public void onEntry() {
-        logger.fine("Setting transport state to NO_MEDIA_PRESENT");
+        logger.debug("Setting transport state to NO_MEDIA_PRESENT");
         getTransport().setTransportInfo(
                 new TransportInfo(
                         TransportState.NO_MEDIA_PRESENT,

--- a/bundles/org.jupnp.support/src/main/java/org/jupnp/support/avtransport/impl/state/PausedPlay.java
+++ b/bundles/org.jupnp.support/src/main/java/org/jupnp/support/avtransport/impl/state/PausedPlay.java
@@ -16,13 +16,14 @@
 package org.jupnp.support.avtransport.impl.state;
 
 import java.net.URI;
-import java.util.logging.Logger;
 
 import org.jupnp.support.avtransport.lastchange.AVTransportVariable;
 import org.jupnp.support.model.AVTransport;
 import org.jupnp.support.model.TransportAction;
 import org.jupnp.support.model.TransportInfo;
 import org.jupnp.support.model.TransportState;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * @author Christian Bauer - Initial Contribution
@@ -31,14 +32,14 @@ import org.jupnp.support.model.TransportState;
 public abstract class PausedPlay<T extends AVTransport> extends AbstractState<T>
 {
 
-    private final Logger logger = Logger.getLogger(PausedPlay.class.getName());
+    private final Logger logger = LoggerFactory.getLogger(PausedPlay.class);
 
     public PausedPlay(T transport) {
         super(transport);
     }
 
     public void onEntry() {
-        logger.fine("Setting transport state to PAUSED_PLAYBACK");
+        logger.debug("Setting transport state to PAUSED_PLAYBACK");
         getTransport().setTransportInfo(
                 new TransportInfo(
                         TransportState.PAUSED_PLAYBACK,

--- a/bundles/org.jupnp.support/src/main/java/org/jupnp/support/avtransport/impl/state/Playing.java
+++ b/bundles/org.jupnp.support/src/main/java/org/jupnp/support/avtransport/impl/state/Playing.java
@@ -21,9 +21,10 @@ import org.jupnp.support.model.SeekMode;
 import org.jupnp.support.model.TransportAction;
 import org.jupnp.support.model.TransportInfo;
 import org.jupnp.support.model.TransportState;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.net.URI;
-import java.util.logging.Logger;
 
 /**
  * @author Christian Bauer - Initial Contribution
@@ -31,14 +32,14 @@ import java.util.logging.Logger;
  */
 public abstract class Playing<T extends AVTransport> extends AbstractState<T> {
 
-    private final Logger logger = Logger.getLogger(Playing.class.getName());
+    private final Logger logger = LoggerFactory.getLogger(Playing.class);
 
     public Playing(T transport) {
         super(transport);
     }
 
     public void onEntry() {
-        logger.fine("Setting transport state to PLAYING");
+        logger.debug("Setting transport state to PLAYING");
         getTransport().setTransportInfo(
                 new TransportInfo(
                         TransportState.PLAYING,

--- a/bundles/org.jupnp.support/src/main/java/org/jupnp/support/avtransport/impl/state/Stopped.java
+++ b/bundles/org.jupnp.support/src/main/java/org/jupnp/support/avtransport/impl/state/Stopped.java
@@ -21,9 +21,10 @@ import org.jupnp.support.model.SeekMode;
 import org.jupnp.support.model.TransportAction;
 import org.jupnp.support.model.TransportInfo;
 import org.jupnp.support.model.TransportState;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.net.URI;
-import java.util.logging.Logger;
 
 /**
  * @author Christian Bauer - Initial Contribution
@@ -31,14 +32,14 @@ import java.util.logging.Logger;
  */
 public abstract class Stopped<T extends AVTransport> extends AbstractState<T> {
 
-    private final Logger log = Logger.getLogger(Stopped.class.getName());
+    private final Logger logger = LoggerFactory.getLogger(Stopped.class);
 
     public Stopped(T transport) {
         super(transport);
     }
 
     public void onEntry() {
-        log.fine("Setting transport state to STOPPED");
+        logger.debug("Setting transport state to STOPPED");
         getTransport().setTransportInfo(
                 new TransportInfo(
                         TransportState.STOPPED,

--- a/bundles/org.jupnp.support/src/main/java/org/jupnp/support/connectionmanager/AbstractPeeringConnectionManagerService.java
+++ b/bundles/org.jupnp.support/src/main/java/org/jupnp/support/connectionmanager/AbstractPeeringConnectionManagerService.java
@@ -15,8 +15,6 @@
 
 package org.jupnp.support.connectionmanager;
 
-import java.util.logging.Logger;
-
 import org.jupnp.binding.annotations.UpnpAction;
 import org.jupnp.binding.annotations.UpnpInputArgument;
 import org.jupnp.binding.annotations.UpnpOutputArgument;
@@ -35,6 +33,8 @@ import org.jupnp.support.connectionmanager.callback.PrepareForConnection;
 import org.jupnp.support.model.ConnectionInfo;
 import org.jupnp.support.model.ProtocolInfo;
 import org.jupnp.support.model.ProtocolInfos;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Support for setup and teardown of an arbitrary number of connections with a manager peer.
@@ -45,7 +45,7 @@ import org.jupnp.support.model.ProtocolInfos;
  */
 public abstract class AbstractPeeringConnectionManagerService extends ConnectionManagerService {
 
-    private final Logger logger = Logger.getLogger(AbstractPeeringConnectionManagerService.class.getName());
+    private final Logger logger = LoggerFactory.getLogger(AbstractPeeringConnectionManagerService.class);
 
     protected AbstractPeeringConnectionManagerService(ConnectionInfo... activeConnections) {
         super(activeConnections);
@@ -73,7 +73,7 @@ public abstract class AbstractPeeringConnectionManagerService extends Connection
     protected synchronized void storeConnection(ConnectionInfo info) {
         CSV<UnsignedIntegerFourBytes> oldConnectionIDs = getCurrentConnectionIDs();
         activeConnections.put(info.getConnectionID(), info);
-        logger.fine("Connection stored, firing event: " + info.getConnectionID());
+        logger.debug("Connection stored, firing event: {}", info.getConnectionID());
         CSV<UnsignedIntegerFourBytes> newConnectionIDs = getCurrentConnectionIDs();
         getPropertyChangeSupport().firePropertyChange("CurrentConnectionIDs", oldConnectionIDs, newConnectionIDs);
     }
@@ -81,7 +81,7 @@ public abstract class AbstractPeeringConnectionManagerService extends Connection
     protected synchronized void removeConnection(int connectionID) {
         CSV<UnsignedIntegerFourBytes> oldConnectionIDs = getCurrentConnectionIDs();
         activeConnections.remove(connectionID);
-        logger.fine("Connection removed, firing event: " + connectionID);
+        logger.debug("Connection removed, firing event: {}", connectionID);
         CSV<UnsignedIntegerFourBytes> newConnectionIDs = getCurrentConnectionIDs();
         getPropertyChangeSupport().firePropertyChange("CurrentConnectionIDs", oldConnectionIDs, newConnectionIDs);
     }
@@ -107,7 +107,7 @@ public abstract class AbstractPeeringConnectionManagerService extends Connection
             throw new ConnectionManagerException(ErrorCode.ARGUMENT_VALUE_INVALID, "Unsupported direction: " + direction);
         }
 
-        logger.fine("Preparing for connection with local new ID " + connectionId + " and peer connection ID: " + peerConnectionId);
+        logger.debug("Preparing for connection with local new ID {} and peer connection ID: {}", connectionId, peerConnectionId);
 
         ConnectionInfo newConnectionInfo = createConnection(
                 connectionId,
@@ -126,7 +126,7 @@ public abstract class AbstractPeeringConnectionManagerService extends Connection
     public synchronized void connectionComplete(@UpnpInputArgument(name = "ConnectionID", stateVariable = "A_ARG_TYPE_ConnectionID") int connectionID)
             throws ActionException {
         ConnectionInfo info = getCurrentConnectionInfo(connectionID);
-        logger.fine("Closing connection ID " + connectionID);
+        logger.debug("Closing connection ID {}", connectionID);
         closeConnection(info);
         removeConnection(connectionID);
     }
@@ -148,7 +148,7 @@ public abstract class AbstractPeeringConnectionManagerService extends Connection
 
         final int localConnectionID = getNewConnectionId();
 
-        logger.fine("Creating new connection ID " + localConnectionID + " with peer: " + peerService);
+        logger.debug("Creating new connection ID {} with peer: {}", localConnectionID, peerService);
         final boolean[] failed = new boolean[1];
         new PrepareForConnection(
                 peerService,
@@ -202,7 +202,7 @@ public abstract class AbstractPeeringConnectionManagerService extends Connection
                                                      final ConnectionInfo connectionInfo) throws ActionException {
 
         // It is important that you synchronize the whole procedure
-        logger.fine("Closing connection ID " + connectionInfo.getConnectionID() + " with peer: " + peerService);
+        logger.debug("Closing connection ID {} with peer: {}", connectionInfo.getConnectionID(), peerService);
         new ConnectionComplete(
                 peerService,
                 controlPoint,

--- a/bundles/org.jupnp.support/src/main/java/org/jupnp/support/connectionmanager/ConnectionManagerService.java
+++ b/bundles/org.jupnp.support/src/main/java/org/jupnp/support/connectionmanager/ConnectionManagerService.java
@@ -17,7 +17,6 @@ package org.jupnp.support.connectionmanager;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.logging.Logger;
 
 import org.jupnp.binding.annotations.UpnpAction;
 import org.jupnp.binding.annotations.UpnpInputArgument;
@@ -36,6 +35,8 @@ import org.jupnp.model.types.csv.CSVUnsignedIntegerFourBytes;
 import org.jupnp.support.model.ConnectionInfo;
 import org.jupnp.support.model.ProtocolInfo;
 import org.jupnp.support.model.ProtocolInfos;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Base for connection management, implements the connection ID "0" behavior.
@@ -63,7 +64,7 @@ import org.jupnp.support.model.ProtocolInfos;
 })
 public class ConnectionManagerService {
 
-    private final Logger logger = Logger.getLogger(ConnectionManagerService.class.getName());
+    private final Logger logger = LoggerFactory.getLogger(ConnectionManagerService.class.getName());
 
     protected final PropertyChangeSupport propertyChangeSupport;
     protected final Map<Integer, ConnectionInfo> activeConnections = new ConcurrentHashMap<>();
@@ -122,7 +123,7 @@ public class ConnectionManagerService {
     })
     public synchronized ConnectionInfo getCurrentConnectionInfo(@UpnpInputArgument(name = "ConnectionID") int connectionId)
             throws ActionException {
-        logger.fine("Getting connection information of connection ID: " + connectionId);
+        logger.debug("Getting connection information of connection ID: {}", connectionId);
         ConnectionInfo info;
         if ((info = activeConnections.get(connectionId)) == null) {
             throw new ConnectionManagerException(
@@ -141,7 +142,7 @@ public class ConnectionManagerService {
         for (Integer connectionID : activeConnections.keySet()) {
             csv.add(new UnsignedIntegerFourBytes(connectionID));
         }
-        logger.fine("Returning current connection IDs: " + csv.size());
+        logger.debug("Returning current connection IDs: {}", csv.size());
         return csv;
     }
 

--- a/bundles/org.jupnp.support/src/main/java/org/jupnp/support/contentdirectory/DIDLParser.java
+++ b/bundles/org.jupnp.support/src/main/java/org/jupnp/support/contentdirectory/DIDLParser.java
@@ -21,8 +21,6 @@ import java.io.InputStream;
 import java.io.StringReader;
 import java.io.StringWriter;
 import java.net.URI;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.transform.OutputKeys;
@@ -48,6 +46,8 @@ import org.jupnp.support.model.item.Item;
 import org.jupnp.util.Exceptions;
 import org.jupnp.util.io.IO;
 import org.jupnp.xml.SAXParser;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
@@ -78,7 +78,7 @@ import org.xml.sax.SAXException;
  */
 public class DIDLParser extends SAXParser {
 
-    private final Logger logger = Logger.getLogger(DIDLParser.class.getName());
+    private final Logger logger = LoggerFactory.getLogger(DIDLParser.class);
 
     public static final String UNKNOWN_TITLE = "Unknown Title";
 
@@ -115,7 +115,7 @@ public class DIDLParser extends SAXParser {
         DIDLContent content = new DIDLContent();
         createRootHandler(content, this);
 
-        logger.fine("Parsing DIDL XML content");
+        logger.debug("Parsing DIDL XML content");
         parse(new InputSource(new StringReader(xml)));
         return content;
     }
@@ -203,7 +203,7 @@ public class DIDLParser extends SAXParser {
                     new ProtocolInfo(attributes.getValue("protocolInfo"))
             );
         } catch (InvalidValueException ex) {
-            logger.warning("In DIDL content, invalid resource protocol info: " + Exceptions.unwrap(ex));
+            logger.warn("In DIDL content, invalid resource protocol info", Exceptions.unwrap(ex));
             return null;
         }
 
@@ -384,7 +384,7 @@ public class DIDLParser extends SAXParser {
 
         String title = container.getTitle();
         if (title == null) {
-            logger.warning("Missing 'dc:title' element for container: " + container.getId());
+            logger.warn("Missing 'dc:title' element for container: {}", container.getId());
             title = UNKNOWN_TITLE;
         }
 
@@ -465,7 +465,7 @@ public class DIDLParser extends SAXParser {
 
         String title = item.getTitle();
         if (title == null) {
-            logger.warning("Missing 'dc:title' element for item: " + item.getId());
+            logger.warn("Missing 'dc:title' element for item: {}" + item.getId());
             title = UNKNOWN_TITLE;
         }
 
@@ -586,7 +586,7 @@ public class DIDLParser extends SAXParser {
             }
 
         } else {
-            logger.warning("Unknown desc metadata content, please override populateDescMetadata(): " + descMeta.getMetadata());
+            logger.warn("Unknown desc metadata content, please override populateDescMetadata(): {}", descMeta.getMetadata());
         }
     }
 
@@ -619,15 +619,15 @@ public class DIDLParser extends SAXParser {
     }
 
     /**
-     * Sends the given string to the log with <code>Level.FINE</code>, if that log level is enabled.
+     * Logs the given string at debug log level if enabled.
      *
      * @param s The string to send to the log.
      */
     public void debugXML(String s) {
-        if (logger.isLoggable(Level.FINE)) {
-            logger.fine("-------------------------------------------------------------------------------------");
-            logger.fine("\n" + s);
-            logger.fine("-------------------------------------------------------------------------------------");
+        if (logger.isDebugEnabled()) {
+            logger.debug("-------------------------------------------------------------------------------------");
+            logger.debug("{}", s);
+            logger.debug("-------------------------------------------------------------------------------------");
         }
     }
 
@@ -950,10 +950,10 @@ public class DIDLParser extends SAXParser {
         protected boolean isLastElement(String uri, String localName, String qName) {
             if (DIDLContent.NAMESPACE_URI.equals(uri) && "container".equals(localName)) {
                 if (getInstance().getTitle() == null) {
-                    logger.warning("In DIDL content, missing 'dc:title' element for container: " + getInstance().getId());
+                    logger.warn("In DIDL content, missing 'dc:title' element for container: {}", getInstance().getId());
                 }
                 if (getInstance().getClazz() == null) {
-                    logger.warning("In DIDL content, missing 'upnp:class' element for container: " + getInstance().getId());
+                    logger.warn("In DIDL content, missing 'upnp:class' element for container: {}", getInstance().getId());
                 }
                 return true;
             }
@@ -993,10 +993,10 @@ public class DIDLParser extends SAXParser {
         protected boolean isLastElement(String uri, String localName, String qName) {
             if (DIDLContent.NAMESPACE_URI.equals(uri) && "item".equals(localName)) {
                 if (getInstance().getTitle() == null) {
-                    logger.warning("In DIDL content, missing 'dc:title' element for item: " + getInstance().getId());
+                    logger.warn("In DIDL content, missing 'dc:title' element for item: {}", getInstance().getId());
                 }
                 if (getInstance().getClazz() == null) {
-                    logger.warning("In DIDL content, missing 'upnp:class' element for item: " + getInstance().getId());
+                    logger.warn("In DIDL content, missing 'upnp:class' element for item: {}", getInstance().getId());
                 }
                 return true;
             }

--- a/bundles/org.jupnp.support/src/main/java/org/jupnp/support/contentdirectory/callback/Browse.java
+++ b/bundles/org.jupnp.support/src/main/java/org/jupnp/support/contentdirectory/callback/Browse.java
@@ -26,8 +26,8 @@ import org.jupnp.support.model.BrowseFlag;
 import org.jupnp.support.model.BrowseResult;
 import org.jupnp.support.model.DIDLContent;
 import org.jupnp.support.model.SortCriterion;
-
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Invokes a "Browse" action, parses the result.
@@ -56,7 +56,7 @@ public abstract class Browse extends ActionCallback {
         }
     }
 
-    private final Logger logger = Logger.getLogger(Browse.class.getName());
+    private final Logger logger = LoggerFactory.getLogger(Browse.class);
 
     /**
      * Browse with first result 0 and {@link #getDefaultMaxResults()}, filters with {@link #CAPS_WILDCARD}.
@@ -73,7 +73,7 @@ public abstract class Browse extends ActionCallback {
 
         super(new ActionInvocation<>(service.getAction("Browse")));
 
-        logger.fine("Creating browse action for object ID: " + objectID);
+        logger.debug("Creating browse action for object ID: {}", objectID);
 
         getActionInvocation().setInput("ObjectID", objectID);
         getActionInvocation().setInput("BrowseFlag", flag.toString());
@@ -92,7 +92,7 @@ public abstract class Browse extends ActionCallback {
     }
 
     public void success(ActionInvocation invocation) {
-        logger.fine("Successful browse action, reading output argument values");
+        logger.debug("Successful browse action, reading output argument values");
 
         BrowseResult result = new BrowseResult(
                 invocation.getOutput("Result").getValue().toString(),
@@ -135,13 +135,6 @@ public abstract class Browse extends ActionCallback {
     }
 
     public boolean receivedRaw(ActionInvocation<?> actionInvocation, BrowseResult browseResult) {
-        /*
-        if (log.isLoggable(Level.FINER)) {
-            log.finer("-------------------------------------------------------------------------------------");
-            log.finer("\n" + XML.pretty(browseResult.getDidl()));
-            log.finer("-------------------------------------------------------------------------------------");
-        }
-        */
         return true;
     }
 

--- a/bundles/org.jupnp.support/src/main/java/org/jupnp/support/contentdirectory/callback/Search.java
+++ b/bundles/org.jupnp.support/src/main/java/org/jupnp/support/contentdirectory/callback/Search.java
@@ -25,8 +25,8 @@ import org.jupnp.support.contentdirectory.DIDLParser;
 import org.jupnp.support.model.DIDLContent;
 import org.jupnp.support.model.SearchResult;
 import org.jupnp.support.model.SortCriterion;
-
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Invokes a "Search" action, parses the result.
@@ -55,7 +55,7 @@ public abstract class Search extends ActionCallback {
         }
     }
 
-    private final Logger logger = Logger.getLogger(Search.class.getName());
+    private final Logger logger = LoggerFactory.getLogger(Search.class);
 
     /**
      * Search with first result 0 and {@link #getDefaultMaxResults()}, filters with {@link #CAPS_WILDCARD}.
@@ -71,7 +71,7 @@ public abstract class Search extends ActionCallback {
                   long firstResult, Long maxResults, SortCriterion... orderBy) {
         super(new ActionInvocation<>(service.getAction("Search")));
 
-        logger.fine("Creating browse action for container ID: " + containerId);
+        logger.debug("Creating browse action for container ID: {}", containerId);
 
         getActionInvocation().setInput("ContainerID", containerId);
         getActionInvocation().setInput("SearchCriteria", searchCriteria);
@@ -92,7 +92,7 @@ public abstract class Search extends ActionCallback {
 
     @Override
     public void success(ActionInvocation actionInvocation) {
-        logger.fine("Successful search action, reading output argument values");
+        logger.debug("Successful search action, reading output argument values");
 
         SearchResult result = new SearchResult(
                 actionInvocation.getOutput("Result").getValue().toString(),

--- a/bundles/org.jupnp.support/src/main/java/org/jupnp/support/lastchange/EventedValueURI.java
+++ b/bundles/org.jupnp.support/src/main/java/org/jupnp/support/lastchange/EventedValueURI.java
@@ -18,9 +18,11 @@ package org.jupnp.support.lastchange;
 import org.jupnp.model.types.Datatype;
 import org.jupnp.model.types.InvalidValueException;
 import org.jupnp.util.Exceptions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.net.URI;
 import java.util.Map;
-import java.util.logging.Logger;
 
 /**
  * @author Christian Bauer - Initial Contribution
@@ -28,7 +30,7 @@ import java.util.logging.Logger;
  */
 public class EventedValueURI extends EventedValue<URI> {
 
-    private final Logger logger = Logger.getLogger(EventedValueURI.class.getName());
+    private final Logger logger = LoggerFactory.getLogger(EventedValueURI.class);
 
     public EventedValueURI(URI value) {
         super(value);
@@ -45,7 +47,7 @@ public class EventedValueURI extends EventedValue<URI> {
             // to parse whatever devices give us, like the Roku which sends "unknown url".
             return super.valueOf(s);
         } catch (InvalidValueException ex) {
-            logger.info("Ignoring invalid URI in evented value '" + s +"': " + Exceptions.unwrap(ex));
+            logger.debug("Ignoring invalid URI in evented value '{}'", s, Exceptions.unwrap(ex));
             return null;
         }
     }

--- a/bundles/org.jupnp.support/src/main/java/org/jupnp/support/lastchange/LastChangeParser.java
+++ b/bundles/org.jupnp.support/src/main/java/org/jupnp/support/lastchange/LastChangeParser.java
@@ -23,8 +23,6 @@ import java.lang.reflect.Constructor;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 import javax.xml.parsers.DocumentBuilderFactory;
 
@@ -35,6 +33,8 @@ import org.jupnp.util.Exceptions;
 import org.jupnp.util.io.IO;
 import org.jupnp.xml.DOMParser;
 import org.jupnp.xml.SAXParser;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.xml.sax.Attributes;
@@ -58,7 +58,7 @@ import org.xml.sax.SAXException;
  */
 public abstract class LastChangeParser extends SAXParser {
 
-    private final Logger logger = Logger.getLogger(LastChangeParser.class.getName());
+    private final Logger logger = LoggerFactory.getLogger(LastChangeParser.class);
 
     public enum CONSTANTS {
         Event,
@@ -112,20 +112,20 @@ public abstract class LastChangeParser extends SAXParser {
         Event event = new Event();
         new RootHandler(event, this);
 
-        if (logger.isLoggable(Level.FINE)) {
-            logger.fine("Parsing 'LastChange' event XML content");
-            logger.fine("===================================== 'LastChange' BEGIN ============================================");
-            logger.fine(xml);
-            logger.fine("====================================== 'LastChange' END  ============================================");
+        if (logger.isDebugEnabled()) {
+            logger.debug("Parsing 'LastChange' event XML content");
+            logger.debug("===================================== 'LastChange' BEGIN ============================================");
+            logger.debug(xml);
+            logger.debug("====================================== 'LastChange' END  ============================================");
         }
         parse(new InputSource(new StringReader(xml)));
 
-        logger.fine("Parsed event with instances IDs: " + event.getInstanceIDs().size());
-        if (logger.isLoggable(Level.FINEST)) {
+        logger.debug("Parsed event with instances IDs: {}", event.getInstanceIDs().size());
+        if (logger.isTraceEnabled()) {
             for (InstanceID instanceID : event.getInstanceIDs()) {
-                logger.finest("InstanceID '" + instanceID.getId() + "' has values: " + instanceID.getValues().size());
+                logger.trace("InstanceID '{}' has values: {}", instanceID.getId(), instanceID.getValues().size());
                 for (EventedValue<?> eventedValue : instanceID.getValues()) {
-                    logger.finest(eventedValue.getName() + " => " + eventedValue.getValue());
+                    logger.trace("{} => {}", eventedValue.getName(), eventedValue.getValue());
                 }
             }
         }
@@ -181,7 +181,7 @@ public abstract class LastChangeParser extends SAXParser {
                     getInstance().getValues().add(esv);
             } catch (Exception ex) {
                 // Don't exit, just log a warning
-                logger.warning("Error reading event XML, ignoring value: " + Exceptions.unwrap(ex));
+                logger.warn("Error reading event XML, ignoring value: {}", Exceptions.unwrap(ex));
             }
         }
 

--- a/bundles/org.jupnp.support/src/main/java/org/jupnp/support/model/Protocol.java
+++ b/bundles/org.jupnp.support/src/main/java/org/jupnp/support/model/Protocol.java
@@ -15,7 +15,8 @@
 
 package org.jupnp.support.model;
 
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * @author Christian Bauer - Initial Contribution
@@ -31,7 +32,7 @@ public enum Protocol {
     XBMC_GET("xbmc-get"),
     OTHER("other");
 
-    private static final Logger logger = Logger.getLogger(Protocol.class.getName());
+    private static final Logger logger = LoggerFactory.getLogger(Protocol.class);
 
     private String protocolString;
 
@@ -50,7 +51,7 @@ public enum Protocol {
                 return protocol;
             }
         }
-        logger.info("Unsupported OTHER protocol string: " + s);
+        logger.info("Unsupported OTHER protocol string: {}", s);
         return OTHER;
     }
 

--- a/bundles/org.jupnp.support/src/main/java/org/jupnp/support/model/dlna/DLNAAttribute.java
+++ b/bundles/org.jupnp.support/src/main/java/org/jupnp/support/model/dlna/DLNAAttribute.java
@@ -17,10 +17,10 @@ package org.jupnp.support.model.dlna;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 import org.jupnp.util.Exceptions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Transforms known and standardized DLNA attributes from/to string representation.
@@ -35,7 +35,7 @@ import org.jupnp.util.Exceptions;
  */
 public abstract class DLNAAttribute<T> {
 
-    private static final Logger logger = Logger.getLogger(DLNAAttribute.class.getName());
+    private static final Logger logger = LoggerFactory.getLogger(DLNAAttribute.class);
 
     /**
      * Maps a standardized DLNA attribute to potential attribute subtypes.
@@ -129,17 +129,16 @@ public abstract class DLNAAttribute<T> {
         for (int i = 0; i < type.getAttributeTypes().length && attr == null; i++) {
             Class<? extends DLNAAttribute<?>> attributeClass = type.getAttributeTypes()[i];
             try {
-                logger.finest("Trying to parse DLNA '" + type + "' with class: " + attributeClass.getSimpleName());
+                logger.trace("Trying to parse DLNA '{}' with class: {}", type, attributeClass.getSimpleName());
                 attr = attributeClass.newInstance();
                 if (attributeValue != null) {
                     attr.setString(attributeValue, contentFormat);
                 }
             } catch (InvalidDLNAProtocolAttributeException ex) {
-                logger.finest("Invalid DLNA attribute value for tested type: " + attributeClass.getSimpleName() + " - " + ex.getMessage());
+                logger.trace("Invalid DLNA attribute value for tested type: {} - {}", attributeClass.getSimpleName(), ex.getMessage());
                 attr = null;
             } catch (Exception ex) {
-                logger.severe("Error instantiating DLNA attribute of type '" + type + "' with value: " + attributeValue);
-                logger.log(Level.SEVERE, "Exception root cause: ", Exceptions.unwrap(ex));
+                logger.error("Error instantiating DLNA attribute of type '{}' with value: {}", type, attributeValue, Exceptions.unwrap(ex));
             }
         }
         return attr;

--- a/bundles/org.jupnp.support/src/main/java/org/jupnp/support/model/dlna/message/DLNAHeaders.java
+++ b/bundles/org.jupnp.support/src/main/java/org/jupnp/support/model/dlna/message/DLNAHeaders.java
@@ -22,10 +22,10 @@ import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 import org.jupnp.model.message.UpnpHeaders;
 import org.jupnp.support.model.dlna.message.header.DLNAHeader;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Provides UPnP header API in addition to plain multi-map HTTP header access.
@@ -36,7 +36,7 @@ import org.jupnp.support.model.dlna.message.header.DLNAHeader;
  */
 public class DLNAHeaders extends UpnpHeaders {
 
-    private final Logger logger = Logger.getLogger(DLNAHeaders.class.getName());
+    private final Logger logger = LoggerFactory.getLogger(DLNAHeaders.class.getName());
 
     protected Map<DLNAHeader.Type, List<UpnpHeader<?>>> parsedDLNAHeaders;
 
@@ -59,7 +59,7 @@ public class DLNAHeaders extends UpnpHeaders {
         
         // This runs as late as possible and only when necessary (getter called and map is dirty)
         parsedDLNAHeaders = new LinkedHashMap<>();
-        logger.log(Level.FINE, "Parsing all HTTP headers for known UPnP headers: {0}", size());
+        logger.debug("Parsing all HTTP headers for known UPnP headers: {}", size());
         for (Entry<String, List<String>> entry : entrySet()) {
             if (entry.getKey() == null) {
                 continue; // Oh yes, the JDK has 'null' HTTP headers
@@ -67,14 +67,14 @@ public class DLNAHeaders extends UpnpHeaders {
 
             DLNAHeader.Type type = DLNAHeader.Type.getByHttpName(entry.getKey());
             if (type == null) {
-                logger.log(Level.FINE, "Ignoring non-UPNP HTTP header: {0}", entry.getKey());
+                logger.debug("Ignoring non-UPNP HTTP header: {}", entry.getKey());
                 continue;
             }
 
             for (String value : entry.getValue()) {
                 UpnpHeader<?> upnpHeader = DLNAHeader.newInstance(type, value);
                 if (upnpHeader == null || upnpHeader.getValue() == null) {
-                    logger.log(Level.FINE, "Ignoring known but non-parsable header (value violates the UDA specification?) '{0}': {1}", new Object[]{type.getHttpName(), value});
+                    logger.debug("Ignoring known but non-parsable header (value violates the UDA specification?) '{}': {}", type.getHttpName(), value);
                 } else {
                     addParsedValue(type, upnpHeader);
                 }
@@ -83,7 +83,7 @@ public class DLNAHeaders extends UpnpHeaders {
     }
 
     protected void addParsedValue(DLNAHeader.Type type, UpnpHeader<?> value) {
-        logger.log(Level.FINE, "Adding parsed header: {0}", value);
+        logger.debug("Adding parsed header: {}", value);
         List<UpnpHeader<?>> list = parsedDLNAHeaders.get(type);
         if (list == null) {
             list = new LinkedList<>();
@@ -166,18 +166,18 @@ public class DLNAHeaders extends UpnpHeaders {
 
     @Override
     public void log() {
-        if (logger.isLoggable(Level.FINE)) {
+        if (logger.isTraceEnabled()) {
             super.log();
             if (parsedDLNAHeaders != null && parsedDLNAHeaders.size() > 0) {
-                logger.fine("########################## PARSED DLNA HEADERS ##########################");
+                logger.trace("########################## PARSED DLNA HEADERS ##########################");
                 for (Map.Entry<DLNAHeader.Type, List<UpnpHeader<?>>> entry : parsedDLNAHeaders.entrySet()) {
-                    logger.log(Level.FINE, "=== TYPE: {0}", entry.getKey());
+                    logger.trace("=== TYPE: {}", entry.getKey());
                     for (UpnpHeader<?> upnpHeader : entry.getValue()) {
-                        logger.log(Level.FINE, "HEADER: {0}", upnpHeader);
+                        logger.trace("HEADER: {}", upnpHeader);
                     }
                 }
             }
-            logger.fine("####################################################################");
+            logger.trace("####################################################################");
         }
     }
 

--- a/bundles/org.jupnp.support/src/main/java/org/jupnp/support/model/dlna/message/header/DLNAHeader.java
+++ b/bundles/org.jupnp.support/src/main/java/org/jupnp/support/model/dlna/message/header/DLNAHeader.java
@@ -18,12 +18,12 @@ package org.jupnp.support.model.dlna.message.header;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 import org.jupnp.model.message.header.InvalidHeaderException;
 import org.jupnp.model.message.header.UpnpHeader;
 import org.jupnp.util.Exceptions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Transforms known and standardized DLNA/HTTP headers from/to string representation.
@@ -38,7 +38,7 @@ import org.jupnp.util.Exceptions;
  */
 public abstract class DLNAHeader<T> extends UpnpHeader<T> {
 
-    private static final Logger logger = Logger.getLogger(DLNAHeader.class.getName());
+    private static final Logger logger = LoggerFactory.getLogger(DLNAHeader.class);
 
     /**
      * Maps a standardized DLNA header to potential header subtypes.
@@ -136,17 +136,16 @@ public abstract class DLNAHeader<T> extends UpnpHeader<T> {
         for (int i = 0; i < type.getHeaderTypes().length && upnpHeader == null; i++) {
             Class<? extends DLNAHeader<?>> headerClass = type.getHeaderTypes()[i];
             try {
-                logger.finest("Trying to parse '" + type + "' with class: " + headerClass.getSimpleName());
+                logger.trace("Trying to parse '{}' with class: {}", type, headerClass.getSimpleName());
                 upnpHeader = headerClass.newInstance();
                 if (headerValue != null) {
                     upnpHeader.setString(headerValue);
                 }
             } catch (InvalidHeaderException ex) {
-                logger.finest("Invalid header value for tested type: " + headerClass.getSimpleName() + " - " + ex.getMessage());
+                logger.trace("Invalid header value for tested type: {}", headerClass.getSimpleName() + " - " + ex.getMessage());
                 upnpHeader = null;
             } catch (Exception ex) {
-                logger.severe("Error instantiating header of type '" + type + "' with value: " + headerValue);
-                logger.log(Level.SEVERE, "Exception root cause: ", Exceptions.unwrap(ex));
+                logger.error("Error instantiating header of type '{}' with value: {}", type, headerValue, Exceptions.unwrap(ex));
             }
 
         }

--- a/bundles/org.jupnp.support/src/main/java/org/jupnp/support/renderingcontrol/callback/SetMute.java
+++ b/bundles/org.jupnp.support/src/main/java/org/jupnp/support/renderingcontrol/callback/SetMute.java
@@ -20,8 +20,8 @@ import org.jupnp.model.action.ActionInvocation;
 import org.jupnp.model.meta.Service;
 import org.jupnp.model.types.UnsignedIntegerFourBytes;
 import org.jupnp.support.model.Channel;
-
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * @author Christian Bauer - Initial Contribution
@@ -29,7 +29,7 @@ import java.util.logging.Logger;
  */
 public abstract class SetMute extends ActionCallback {
 
-    private final Logger logger = Logger.getLogger(SetMute.class.getName());
+    private final Logger logger = LoggerFactory.getLogger(SetMute.class.getName());
 
     public SetMute(Service<?, ?> service, boolean desiredMute) {
         this(new UnsignedIntegerFourBytes(0), service, desiredMute);
@@ -44,7 +44,6 @@ public abstract class SetMute extends ActionCallback {
 
     @Override
     public void success(ActionInvocation invocation) {
-        logger.fine("Executed successfully");
-
+        logger.debug("Executed successfully");
     }
 }

--- a/bundles/org.jupnp.support/src/main/java/org/jupnp/support/renderingcontrol/callback/SetVolume.java
+++ b/bundles/org.jupnp.support/src/main/java/org/jupnp/support/renderingcontrol/callback/SetVolume.java
@@ -21,8 +21,8 @@ import org.jupnp.model.meta.Service;
 import org.jupnp.model.types.UnsignedIntegerFourBytes;
 import org.jupnp.model.types.UnsignedIntegerTwoBytes;
 import org.jupnp.support.model.Channel;
-
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * @author Christian Bauer - Initial Contribution
@@ -30,7 +30,7 @@ import java.util.logging.Logger;
  */
 public abstract class SetVolume extends ActionCallback {
 
-    private final Logger logger = Logger.getLogger(SetVolume.class.getName());
+    private final Logger logger = LoggerFactory.getLogger(SetVolume.class);
 
     public SetVolume(Service<?, ?> service, long newVolume) {
         this(new UnsignedIntegerFourBytes(0), service, newVolume);
@@ -45,7 +45,6 @@ public abstract class SetVolume extends ActionCallback {
 
     @Override
     public void success(ActionInvocation invocation) {
-        logger.fine("Executed successfully");
-
+        logger.debug("Executed successfully");
     }
 }


### PR DESCRIPTION
Updates the remaining classes that use java.util.logging for logging with SLF4J.
SLF4J is already used for logging by most of the code.