### PR TITLE
Remove usage of deprecated SecurityManager

### DIFF
--- a/bundles/org.jupnp/src/main/java/org/jupnp/DefaultUpnpServiceConfiguration.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/DefaultUpnpServiceConfiguration.java
@@ -400,8 +400,7 @@ public class DefaultUpnpServiceConfiguration implements UpnpServiceConfiguration
         protected final String namePrefix = "jupnp-";
 
         public JUPnPThreadFactory() {
-            SecurityManager s = System.getSecurityManager();
-            group = (s != null) ? s.getThreadGroup() : Thread.currentThread().getThreadGroup();
+            group = Thread.currentThread().getThreadGroup();
         }
 
         @Override

--- a/bundles/org.jupnp/src/main/java/org/jupnp/QueueingThreadPoolExecutor.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/QueueingThreadPoolExecutor.java
@@ -237,8 +237,7 @@ public class QueueingThreadPoolExecutor extends ThreadPoolExecutor {
 
         public CommonThreadFactory(String name) {
             this.name = name;
-            SecurityManager s = System.getSecurityManager();
-            group = (s != null) ? s.getThreadGroup() : Thread.currentThread().getThreadGroup();
+            group = Thread.currentThread().getThreadGroup();
         }
 
         @Override

--- a/bundles/org.jupnp/src/test/java/org/jupnp/service/QueueingThreadPoolExecutorTest.java
+++ b/bundles/org.jupnp/src/test/java/org/jupnp/service/QueueingThreadPoolExecutorTest.java
@@ -271,60 +271,6 @@ class QueueingThreadPoolExecutorTest {
 	}
 
 	/**
-	 * Tests using security manager with high max thread group priority.
-	 */
-	@Test
-	void testPoolSize2ThreadSettingsWithSecurityManagerThreadGroupMaxPriority() throws InterruptedException {
-		SecurityManager sm = System.getSecurityManager();
-		try {
-			System.setSecurityManager(new SecurityManager() {
-				@Override
-				public void checkPermission(Permission perm) {
-				}
-
-				@Override
-				public ThreadGroup getThreadGroup() {
-					ThreadGroup g = new ThreadGroup("TestMaxThreadGroup");
-					g.setDaemon(true);
-					g.setMaxPriority(Thread.MAX_PRIORITY);
-					return g;
-				}
-			});
-			String poolName = "testPoolSize2ThreadSettingsWithSecurityManagerThreadGroupMaxPriority";
-			basicTestPoolSize2ThreadSettings(poolName);
-		} finally {
-			System.setSecurityManager(sm);
-		}
-	}
-
-	/**
-	 * Tests using security manager with low min thread group priority.
-	 */
-	@Test
-	void testPoolSize2ThreadSettingsWithSecurityManagerThreadGroupMinPriority() throws InterruptedException {
-		SecurityManager sm = System.getSecurityManager();
-		try {
-			System.setSecurityManager(new SecurityManager() {
-				@Override
-				public void checkPermission(Permission perm) {
-				}
-
-				@Override
-				public ThreadGroup getThreadGroup() {
-					ThreadGroup g = new ThreadGroup("TestMinThreadGroup");
-					g.setDaemon(true);
-					g.setMaxPriority(Thread.MIN_PRIORITY);
-					return g;
-				}
-			});
-			String poolName = "testPoolSize2ThreadSettingsWithSecurityManagerThreadGroupMinPriority";
-			basicTestPoolSize2ThreadSettings(poolName);
-		} finally {
-			System.setSecurityManager(sm);
-		}
-	}
-
-	/**
 	 * Test basic thread creation, including thread settings (name, prio,
 	 * daemon).
 	 */


### PR DESCRIPTION
See: https://openjdk.org/jeps/411

Fixes warnings:

WARNING: A terminally deprecated method in java.lang.System has been called
WARNING: System::setSecurityManager has been called by org.jupnp.service.QueueingThreadPoolExecutorTest
WARNING: Please consider reporting this to the maintainers of org.jupnp.service.QueueingThreadPoolExecutorTest
WARNING: System::setSecurityManager will be removed in a future release