### PR TITLE
Add Maven Central and Javadocs badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 [![GitHub Actions Build Status](https://github.com/jupnp/jupnp/actions/workflows/ci-build.yml/badge.svg?branch=main)](https://github.com/jupnp/jupnp/actions/workflows/ci-build.yml)
 [![CDDL-1.0](https://img.shields.io/badge/license-CDDL%201.0-green.svg)](https://opensource.org/licenses/CDDL-1.0)
+[![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.jupnp/org.jupnp/badge.svg)](https://maven-badges.herokuapp.com/maven-central/org.jupnp/org.jupnp) 
+[![Javadocs](https://www.javadoc.io/badge/org.jupnp/org.jupnp.svg)](https://www.javadoc.io/doc/org.jupnp/org.jupnp)
 
 # Introduction
 


### PR DESCRIPTION
These badges will make it easier to find the latest version on Maven Central as well as read the Javadocs.