### PR TITLE
Use static inner classes

### DIFF
--- a/bundles/org.jupnp.osgi/src/main/java/org/jupnp/osgi/discover/JUPnPRegistryListener.java
+++ b/bundles/org.jupnp.osgi/src/main/java/org/jupnp/osgi/discover/JUPnPRegistryListener.java
@@ -68,7 +68,7 @@ class JUPnPRegistryListener extends DefaultRegistryListener {
     private final BundleContext context;
     private final UpnpService upnpService;
 
-    class UPnPDeviceBinding {
+    static class UPnPDeviceBinding {
         private ServiceRegistration reference;
         private ServiceTracker tracker;
 

--- a/bundles/org.jupnp.support/src/main/java/org/jupnp/support/contentdirectory/DIDLParser.java
+++ b/bundles/org.jupnp.support/src/main/java/org/jupnp/support/contentdirectory/DIDLParser.java
@@ -899,7 +899,7 @@ public class DIDLParser extends SAXParser {
         }
     }
 
-    protected class ResHandler extends Handler<Res> {
+    protected static class ResHandler extends Handler<Res> {
         public ResHandler(Res instance, Handler<?> parent) {
             super(instance, parent);
         }
@@ -924,7 +924,7 @@ public class DIDLParser extends SAXParser {
      * </p>
      */
     @SuppressWarnings({ "rawtypes", "unchecked" })
-    public class DescMetaHandler extends Handler<DescMeta> {
+    public static class DescMetaHandler extends Handler<DescMeta> {
 
         protected Element current;
 

--- a/bundles/org.jupnp/src/main/java/org/jupnp/xml/DOMElement.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/xml/DOMElement.java
@@ -262,7 +262,7 @@ public abstract class DOMElement<CHILD extends DOMElement, PARENT extends DOMEle
         }
     }
 
-    public abstract class Builder<T extends DOMElement> {
+    public abstract static class Builder<T extends DOMElement> {
         public DOMElement element;
 
         protected Builder(DOMElement element) {
@@ -277,7 +277,7 @@ public abstract class DOMElement<CHILD extends DOMElement, PARENT extends DOMEle
         }
     }
 
-    public abstract class ArrayBuilder<T extends DOMElement> extends Builder<T> {
+    public abstract static class ArrayBuilder<T extends DOMElement> extends Builder<T> {
 
         protected ArrayBuilder(DOMElement element) {
             super(element);

--- a/bundles/org.jupnp/src/main/java/org/jupnp/xml/SAXParser.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/xml/SAXParser.java
@@ -115,7 +115,7 @@ public class SAXParser {
     /**
      * Always throws exceptions and stops parsing.
      */
-    public class SimpleErrorHandler implements ErrorHandler {
+    public static class SimpleErrorHandler implements ErrorHandler {
         public void warning(SAXParseException e) throws SAXException {
             throw new SAXException(e);
         }

--- a/bundles/org.jupnp/src/test/java/example/controlpoint/ActionInvocationTest.java
+++ b/bundles/org.jupnp/src/test/java/example/controlpoint/ActionInvocationTest.java
@@ -368,7 +368,7 @@ class ActionInvocationTest {
             return new MyStringHolder(myString);
         }
 
-        public class StatusHolder {
+        public static class StatusHolder {
             boolean st;
 
             public StatusHolder(boolean st) {
@@ -380,7 +380,7 @@ class ActionInvocationTest {
             }
         }
 
-        public class MyStringHolder {
+        public static class MyStringHolder {
             MyString myString;
 
             public MyStringHolder(MyString myString) {

--- a/bundles/org.jupnp/src/test/java/example/localservice/SwitchPowerBeanReturn.java
+++ b/bundles/org.jupnp/src/test/java/example/localservice/SwitchPowerBeanReturn.java
@@ -60,7 +60,7 @@ public class SwitchPowerBeanReturn {
         return new StatusHolder(status);
     }
 
-    public class StatusHolder {
+    public static class StatusHolder {
         boolean wrapped;
 
         public StatusHolder(boolean wrapped) {

--- a/bundles/org.jupnp/src/test/java/example/registry/RegistryListenerTest.java
+++ b/bundles/org.jupnp/src/test/java/example/registry/RegistryListenerTest.java
@@ -178,7 +178,7 @@ class RegistryListenerTest {
         assertTrue(listener.valid);
     }
 
-    public class QuickstartRegistryListener extends DefaultRegistryListener {
+    public static class QuickstartRegistryListener extends DefaultRegistryListener {
         public boolean valid = false; // DOC: EXC1
 
         @Override
@@ -201,7 +201,7 @@ class RegistryListenerTest {
         }
     }
 
-    public class FailureQuickstartRegistryListener extends DefaultRegistryListener {
+    public static class FailureQuickstartRegistryListener extends DefaultRegistryListener {
         public boolean valid = false;
 
         @Override


### PR DESCRIPTION
A static inner class does not keep an implicit reference to its enclosing instance. This prevents a common cause of memory leaks and uses less memory per instance of the class.