### PR TITLE
Add missing `@Override` annotations

### DIFF
--- a/bundles/org.jupnp.support/src/main/java/org/jupnp/support/avtransport/callback/GetCurrentTransportActions.java
+++ b/bundles/org.jupnp.support/src/main/java/org/jupnp/support/avtransport/callback/GetCurrentTransportActions.java
@@ -36,6 +36,7 @@ public abstract class GetCurrentTransportActions extends ActionCallback {
         getActionInvocation().setInput("InstanceID", instanceId);
     }
 
+    @Override
     public void success(ActionInvocation invocation) {
         String actionsString = (String) invocation.getOutput("Actions").getValue();
         received(invocation, TransportAction.valueOfCommaSeparatedList(actionsString));

--- a/bundles/org.jupnp.support/src/main/java/org/jupnp/support/avtransport/callback/GetDeviceCapabilities.java
+++ b/bundles/org.jupnp.support/src/main/java/org/jupnp/support/avtransport/callback/GetDeviceCapabilities.java
@@ -36,6 +36,7 @@ public abstract class GetDeviceCapabilities extends ActionCallback {
         getActionInvocation().setInput("InstanceID", instanceId);
     }
 
+    @Override
     public void success(ActionInvocation invocation) {
         DeviceCapabilities caps = new DeviceCapabilities(invocation.getOutputMap());
         received(invocation, caps);

--- a/bundles/org.jupnp.support/src/main/java/org/jupnp/support/avtransport/callback/GetMediaInfo.java
+++ b/bundles/org.jupnp.support/src/main/java/org/jupnp/support/avtransport/callback/GetMediaInfo.java
@@ -36,6 +36,7 @@ public abstract class GetMediaInfo extends ActionCallback {
         getActionInvocation().setInput("InstanceID", instanceId);
     }
 
+    @Override
     public void success(ActionInvocation invocation) {
         MediaInfo mediaInfo = new MediaInfo(invocation.getOutputMap());
         received(invocation, mediaInfo);

--- a/bundles/org.jupnp.support/src/main/java/org/jupnp/support/avtransport/callback/GetPositionInfo.java
+++ b/bundles/org.jupnp.support/src/main/java/org/jupnp/support/avtransport/callback/GetPositionInfo.java
@@ -36,6 +36,7 @@ public abstract class GetPositionInfo extends ActionCallback {
         getActionInvocation().setInput("InstanceID", instanceId);
     }
 
+    @Override
     public void success(ActionInvocation invocation) {
         PositionInfo positionInfo = new PositionInfo(invocation.getOutputMap());
         received(invocation, positionInfo);

--- a/bundles/org.jupnp.support/src/main/java/org/jupnp/support/avtransport/callback/GetTransportInfo.java
+++ b/bundles/org.jupnp.support/src/main/java/org/jupnp/support/avtransport/callback/GetTransportInfo.java
@@ -36,6 +36,7 @@ public abstract class GetTransportInfo extends ActionCallback {
         getActionInvocation().setInput("InstanceID", instanceId);
     }
 
+    @Override
     public void success(ActionInvocation invocation) {
         TransportInfo transportInfo = new TransportInfo(invocation.getOutputMap());
         received(invocation, transportInfo);

--- a/bundles/org.jupnp.support/src/main/java/org/jupnp/support/avtransport/impl/AVTransportService.java
+++ b/bundles/org.jupnp.support/src/main/java/org/jupnp/support/avtransport/impl/AVTransportService.java
@@ -102,6 +102,7 @@ public class AVTransportService<T extends AVTransport> extends AbstractAVTranspo
         this.transportClass = transportClass;
     }
 
+    @Override
     public void setAVTransportURI(UnsignedIntegerFourBytes instanceId, String currentURI, String currentURIMetaData)
             throws AVTransportException {
 
@@ -120,6 +121,7 @@ public class AVTransportService<T extends AVTransport> extends AbstractAVTranspo
         }
     }
 
+    @Override
     public void setNextAVTransportURI(UnsignedIntegerFourBytes instanceId, String nextURI, String nextURIMetaData)
             throws AVTransportException {
 
@@ -138,6 +140,7 @@ public class AVTransportService<T extends AVTransport> extends AbstractAVTranspo
         }
     }
 
+    @Override
     public void setPlayMode(UnsignedIntegerFourBytes instanceId, String newPlayMode) throws AVTransportException {
         AVTransport transport = findStateMachine(instanceId).getCurrentState().getTransport();
         try {
@@ -149,6 +152,7 @@ public class AVTransportService<T extends AVTransport> extends AbstractAVTranspo
         }
     }
 
+    @Override
     public void setRecordQualityMode(UnsignedIntegerFourBytes instanceId, String newRecordQualityMode)
             throws AVTransportException {
         AVTransport transport = findStateMachine(instanceId).getCurrentState().getTransport();
@@ -161,26 +165,32 @@ public class AVTransportService<T extends AVTransport> extends AbstractAVTranspo
         }
     }
 
+    @Override
     public MediaInfo getMediaInfo(UnsignedIntegerFourBytes instanceId) throws AVTransportException {
         return findStateMachine(instanceId).getCurrentState().getTransport().getMediaInfo();
     }
 
+    @Override
     public TransportInfo getTransportInfo(UnsignedIntegerFourBytes instanceId) throws AVTransportException {
         return findStateMachine(instanceId).getCurrentState().getTransport().getTransportInfo();
     }
 
+    @Override
     public PositionInfo getPositionInfo(UnsignedIntegerFourBytes instanceId) throws AVTransportException {
         return findStateMachine(instanceId).getCurrentState().getTransport().getPositionInfo();
     }
 
+    @Override
     public DeviceCapabilities getDeviceCapabilities(UnsignedIntegerFourBytes instanceId) throws AVTransportException {
         return findStateMachine(instanceId).getCurrentState().getTransport().getDeviceCapabilities();
     }
 
+    @Override
     public TransportSettings getTransportSettings(UnsignedIntegerFourBytes instanceId) throws AVTransportException {
         return findStateMachine(instanceId).getCurrentState().getTransport().getTransportSettings();
     }
 
+    @Override
     public void stop(UnsignedIntegerFourBytes instanceId) throws AVTransportException {
         try {
             findStateMachine(instanceId).stop();
@@ -189,6 +199,7 @@ public class AVTransportService<T extends AVTransport> extends AbstractAVTranspo
         }
     }
 
+    @Override
     public void play(UnsignedIntegerFourBytes instanceId, String speed) throws AVTransportException {
         try {
             findStateMachine(instanceId).play(speed);
@@ -197,6 +208,7 @@ public class AVTransportService<T extends AVTransport> extends AbstractAVTranspo
         }
     }
 
+    @Override
     public void pause(UnsignedIntegerFourBytes instanceId) throws AVTransportException {
         try {
             findStateMachine(instanceId).pause();
@@ -205,6 +217,7 @@ public class AVTransportService<T extends AVTransport> extends AbstractAVTranspo
         }
     }
 
+    @Override
     public void record(UnsignedIntegerFourBytes instanceId) throws AVTransportException {
         try {
             findStateMachine(instanceId).record();
@@ -213,6 +226,7 @@ public class AVTransportService<T extends AVTransport> extends AbstractAVTranspo
         }
     }
 
+    @Override
     public void seek(UnsignedIntegerFourBytes instanceId, String unit, String target) throws AVTransportException {
         SeekMode seekMode;
         try {
@@ -229,6 +243,7 @@ public class AVTransportService<T extends AVTransport> extends AbstractAVTranspo
         }
     }
 
+    @Override
     public void next(UnsignedIntegerFourBytes instanceId) throws AVTransportException {
         try {
             findStateMachine(instanceId).next();
@@ -237,6 +252,7 @@ public class AVTransportService<T extends AVTransport> extends AbstractAVTranspo
         }
     }
 
+    @Override
     public void previous(UnsignedIntegerFourBytes instanceId) throws AVTransportException {
         try {
             findStateMachine(instanceId).previous();

--- a/bundles/org.jupnp.support/src/main/java/org/jupnp/support/avtransport/impl/state/NoMediaPresent.java
+++ b/bundles/org.jupnp.support/src/main/java/org/jupnp/support/avtransport/impl/state/NoMediaPresent.java
@@ -49,6 +49,7 @@ public abstract class NoMediaPresent<T extends AVTransport> extends AbstractStat
 
     public abstract Class<? extends AbstractState<?>> setTransportURI(URI uri, String metaData);
 
+    @Override
     public TransportAction[] getCurrentTransportActions() {
         return new TransportAction[] { TransportAction.Stop };
     }

--- a/bundles/org.jupnp.support/src/main/java/org/jupnp/support/avtransport/impl/state/PausedPlay.java
+++ b/bundles/org.jupnp.support/src/main/java/org/jupnp/support/avtransport/impl/state/PausedPlay.java
@@ -53,6 +53,7 @@ public abstract class PausedPlay<T extends AVTransport> extends AbstractState<T>
 
     public abstract Class<? extends AbstractState<?>> play(String speed);
 
+    @Override
     public TransportAction[] getCurrentTransportActions() {
         return new TransportAction[] { TransportAction.Stop, TransportAction.Play };
     }

--- a/bundles/org.jupnp.support/src/main/java/org/jupnp/support/avtransport/impl/state/Playing.java
+++ b/bundles/org.jupnp.support/src/main/java/org/jupnp/support/avtransport/impl/state/Playing.java
@@ -62,6 +62,7 @@ public abstract class Playing<T extends AVTransport> extends AbstractState<T> {
 
     public abstract Class<? extends AbstractState<?>> seek(SeekMode unit, String target);
 
+    @Override
     public TransportAction[] getCurrentTransportActions() {
         return new TransportAction[] { TransportAction.Stop, TransportAction.Play, TransportAction.Pause,
                 TransportAction.Next, TransportAction.Previous, TransportAction.Seek };

--- a/bundles/org.jupnp.support/src/main/java/org/jupnp/support/avtransport/impl/state/Stopped.java
+++ b/bundles/org.jupnp.support/src/main/java/org/jupnp/support/avtransport/impl/state/Stopped.java
@@ -60,6 +60,7 @@ public abstract class Stopped<T extends AVTransport> extends AbstractState<T> {
 
     public abstract Class<? extends AbstractState<?>> seek(SeekMode unit, String target);
 
+    @Override
     public TransportAction[] getCurrentTransportActions() {
         return new TransportAction[] { TransportAction.Stop, TransportAction.Play, TransportAction.Next,
                 TransportAction.Previous, TransportAction.Seek };

--- a/bundles/org.jupnp.support/src/main/java/org/jupnp/support/contentdirectory/callback/Browse.java
+++ b/bundles/org.jupnp.support/src/main/java/org/jupnp/support/contentdirectory/callback/Browse.java
@@ -90,6 +90,7 @@ public abstract class Browse extends ActionCallback {
         super.run();
     }
 
+    @Override
     public void success(ActionInvocation invocation) {
         logger.debug("Successful browse action, reading output argument values");
 

--- a/bundles/org.jupnp.support/src/main/java/org/jupnp/support/contentdirectory/callback/GetSystemUpdateID.java
+++ b/bundles/org.jupnp.support/src/main/java/org/jupnp/support/contentdirectory/callback/GetSystemUpdateID.java
@@ -31,6 +31,7 @@ public abstract class GetSystemUpdateID extends ActionCallback {
         super(new ActionInvocation<>(service.getAction("GetSystemUpdateID")));
     }
 
+    @Override
     public void success(ActionInvocation invocation) {
         boolean ok = true;
         long id = 0;

--- a/bundles/org.jupnp.support/src/main/java/org/jupnp/support/messagebox/model/DateTime.java
+++ b/bundles/org.jupnp.support/src/main/java/org/jupnp/support/messagebox/model/DateTime.java
@@ -45,6 +45,7 @@ public class DateTime implements ElementAppender {
         return time;
     }
 
+    @Override
     public void appendMessageElements(MessageElement parent) {
         parent.createChild("Date").setContent(getDate());
         parent.createChild("Time").setContent(getTime());

--- a/bundles/org.jupnp.support/src/main/java/org/jupnp/support/messagebox/model/MessageIncomingCall.java
+++ b/bundles/org.jupnp.support/src/main/java/org/jupnp/support/messagebox/model/MessageIncomingCall.java
@@ -54,6 +54,7 @@ public class MessageIncomingCall extends Message {
         return caller;
     }
 
+    @Override
     public void appendMessageElements(MessageElement parent) {
         getCallTime().appendMessageElements(parent.createChild("CallTime"));
         getCallee().appendMessageElements(parent.createChild("Callee"));

--- a/bundles/org.jupnp.support/src/main/java/org/jupnp/support/messagebox/model/MessageSMS.java
+++ b/bundles/org.jupnp.support/src/main/java/org/jupnp/support/messagebox/model/MessageSMS.java
@@ -63,6 +63,7 @@ public class MessageSMS extends Message {
         return body;
     }
 
+    @Override
     public void appendMessageElements(MessageElement parent) {
         getReceiveTime().appendMessageElements(parent.createChild("ReceiveTime"));
         getReceiver().appendMessageElements(parent.createChild("Receiver"));

--- a/bundles/org.jupnp.support/src/main/java/org/jupnp/support/messagebox/model/MessageScheduleReminder.java
+++ b/bundles/org.jupnp.support/src/main/java/org/jupnp/support/messagebox/model/MessageScheduleReminder.java
@@ -70,6 +70,7 @@ public class MessageScheduleReminder extends Message {
         return body;
     }
 
+    @Override
     public void appendMessageElements(MessageElement parent) {
         getStartTime().appendMessageElements(parent.createChild("StartTime"));
         getOwner().appendMessageElements(parent.createChild("Owner"));

--- a/bundles/org.jupnp.support/src/main/java/org/jupnp/support/messagebox/model/NumberName.java
+++ b/bundles/org.jupnp.support/src/main/java/org/jupnp/support/messagebox/model/NumberName.java
@@ -39,6 +39,7 @@ public class NumberName implements ElementAppender {
         return name;
     }
 
+    @Override
     public void appendMessageElements(MessageElement parent) {
         parent.createChild("Number").setContent(getNumber());
         parent.createChild("Name").setContent(getName());

--- a/bundles/org.jupnp.support/src/main/java/org/jupnp/support/model/dlna/DLNAConversionIndicatorAttribute.java
+++ b/bundles/org.jupnp.support/src/main/java/org/jupnp/support/model/dlna/DLNAConversionIndicatorAttribute.java
@@ -29,6 +29,7 @@ public class DLNAConversionIndicatorAttribute extends DLNAAttribute<DLNAConversi
         setValue(indicator);
     }
 
+    @Override
     public void setString(String s, String cf) {
         DLNAConversionIndicator value = null;
         try {
@@ -41,6 +42,7 @@ public class DLNAConversionIndicatorAttribute extends DLNAAttribute<DLNAConversi
         setValue(value);
     }
 
+    @Override
     public String getString() {
         return Integer.toString(getValue().getCode());
     }

--- a/bundles/org.jupnp.support/src/main/java/org/jupnp/support/model/dlna/DLNAFlagsAttribute.java
+++ b/bundles/org.jupnp.support/src/main/java/org/jupnp/support/model/dlna/DLNAFlagsAttribute.java
@@ -40,6 +40,7 @@ public class DLNAFlagsAttribute extends DLNAAttribute<EnumSet<DLNAFlags>> {
         }
     }
 
+    @Override
     public void setString(String s, String cf) {
         EnumSet<DLNAFlags> value = EnumSet.noneOf(DLNAFlags.class);
         try {
@@ -61,6 +62,7 @@ public class DLNAFlagsAttribute extends DLNAAttribute<EnumSet<DLNAFlags>> {
         setValue(value);
     }
 
+    @Override
     public String getString() {
         int code = 0;
         for (DLNAFlags op : getValue()) {

--- a/bundles/org.jupnp.support/src/main/java/org/jupnp/support/model/dlna/DLNAOperationsAttribute.java
+++ b/bundles/org.jupnp.support/src/main/java/org/jupnp/support/model/dlna/DLNAOperationsAttribute.java
@@ -40,6 +40,7 @@ public class DLNAOperationsAttribute extends DLNAAttribute<EnumSet<DLNAOperation
         }
     }
 
+    @Override
     public void setString(String s, String cf) {
         EnumSet<DLNAOperations> value = EnumSet.noneOf(DLNAOperations.class);
         try {
@@ -61,6 +62,7 @@ public class DLNAOperationsAttribute extends DLNAAttribute<EnumSet<DLNAOperation
         setValue(value);
     }
 
+    @Override
     public String getString() {
         int code = DLNAOperations.NONE.getCode();
         for (DLNAOperations op : getValue()) {

--- a/bundles/org.jupnp.support/src/main/java/org/jupnp/support/model/dlna/DLNAPlaySpeedAttribute.java
+++ b/bundles/org.jupnp.support/src/main/java/org/jupnp/support/model/dlna/DLNAPlaySpeedAttribute.java
@@ -44,6 +44,7 @@ public class DLNAPlaySpeedAttribute extends DLNAAttribute<TransportPlaySpeed[]> 
         setValue(sp);
     }
 
+    @Override
     public void setString(String s, String cf) {
         TransportPlaySpeed[] value = null;
         if (s != null && !s.isEmpty()) {
@@ -63,6 +64,7 @@ public class DLNAPlaySpeedAttribute extends DLNAAttribute<TransportPlaySpeed[]> 
         setValue(value);
     }
 
+    @Override
     public String getString() {
         StringBuilder sb = new StringBuilder();
         for (TransportPlaySpeed speed : getValue()) {

--- a/bundles/org.jupnp.support/src/main/java/org/jupnp/support/model/dlna/DLNAProfileAttribute.java
+++ b/bundles/org.jupnp.support/src/main/java/org/jupnp/support/model/dlna/DLNAProfileAttribute.java
@@ -29,6 +29,7 @@ public class DLNAProfileAttribute extends DLNAAttribute<DLNAProfiles> {
         setValue(profile);
     }
 
+    @Override
     public void setString(String s, String cf) {
         DLNAProfiles value = DLNAProfiles.valueOf(s, cf);
         if (value == null) {
@@ -37,6 +38,7 @@ public class DLNAProfileAttribute extends DLNAAttribute<DLNAProfiles> {
         setValue(value);
     }
 
+    @Override
     public String getString() {
         return getValue().getCode();
     }

--- a/bundles/org.jupnp.support/src/main/java/org/jupnp/support/renderingcontrol/callback/GetMute.java
+++ b/bundles/org.jupnp.support/src/main/java/org/jupnp/support/renderingcontrol/callback/GetMute.java
@@ -37,6 +37,7 @@ public abstract class GetMute extends ActionCallback {
         getActionInvocation().setInput("Channel", Channel.Master.toString());
     }
 
+    @Override
     public void success(ActionInvocation invocation) {
         boolean currentMute = (Boolean) invocation.getOutput("CurrentMute").getValue();
         received(invocation, currentMute);

--- a/bundles/org.jupnp.support/src/main/java/org/jupnp/support/renderingcontrol/callback/GetVolume.java
+++ b/bundles/org.jupnp.support/src/main/java/org/jupnp/support/renderingcontrol/callback/GetVolume.java
@@ -39,6 +39,7 @@ public abstract class GetVolume extends ActionCallback {
         getActionInvocation().setInput("Channel", Channel.Master.toString());
     }
 
+    @Override
     public void success(ActionInvocation invocation) {
         boolean ok = true;
         int currentVolume = 0;

--- a/bundles/org.jupnp.support/src/main/java/org/jupnp/support/shared/AbstractMap.java
+++ b/bundles/org.jupnp.support/src/main/java/org/jupnp/support/shared/AbstractMap.java
@@ -65,10 +65,12 @@ public abstract class AbstractMap<K, V> implements Map<K, V> {
             value = copyFrom.getValue();
         }
 
+        @Override
         public K getKey() {
             return key;
         }
 
+        @Override
         public V getValue() {
             return value;
         }
@@ -77,6 +79,7 @@ public abstract class AbstractMap<K, V> implements Map<K, V> {
          * This base implementation throws {@code UnsupportedOperationException}
          * always.
          */
+        @Override
         public V setValue(V object) {
             throw new UnsupportedOperationException();
         }
@@ -129,14 +132,17 @@ public abstract class AbstractMap<K, V> implements Map<K, V> {
             value = copyFrom.getValue();
         }
 
+        @Override
         public K getKey() {
             return key;
         }
 
+        @Override
         public V getValue() {
             return value;
         }
 
+        @Override
         public V setValue(V object) {
             V result = value;
             value = object;
@@ -177,6 +183,7 @@ public abstract class AbstractMap<K, V> implements Map<K, V> {
      * <p>
      * This implementation calls {@code entrySet().clear()}.
      */
+    @Override
     public void clear() {
         entrySet().clear();
     }
@@ -188,6 +195,7 @@ public abstract class AbstractMap<K, V> implements Map<K, V> {
      * This implementation iterates its key set, looking for a key that
      * {@code key} equals.
      */
+    @Override
     public boolean containsKey(Object key) {
         Iterator<Map.Entry<K, V>> it = entrySet().iterator();
         if (key != null) {
@@ -213,6 +221,7 @@ public abstract class AbstractMap<K, V> implements Map<K, V> {
      * This implementation iterates its entry set, looking for an entry with
      * a value that {@code value} equals.
      */
+    @Override
     public boolean containsValue(Object value) {
         Iterator<Map.Entry<K, V>> it = entrySet().iterator();
         if (value != null) {
@@ -231,6 +240,7 @@ public abstract class AbstractMap<K, V> implements Map<K, V> {
         return false;
     }
 
+    @Override
     public abstract Set<Map.Entry<K, V>> entrySet();
 
     /**
@@ -284,6 +294,7 @@ public abstract class AbstractMap<K, V> implements Map<K, V> {
      * This implementation iterates its entry set, looking for an entry with
      * a key that {@code key} equals.
      */
+    @Override
     public V get(Object key) {
         Iterator<Map.Entry<K, V>> it = entrySet().iterator();
         if (key != null) {
@@ -326,6 +337,7 @@ public abstract class AbstractMap<K, V> implements Map<K, V> {
      * <p>
      * This implementation compares {@code size()} to 0.
      */
+    @Override
     public boolean isEmpty() {
         return size() == 0;
     }
@@ -337,6 +349,7 @@ public abstract class AbstractMap<K, V> implements Map<K, V> {
      * This implementation returns a view that calls through this to map. Its
      * iterator transforms this map's entry set iterator to return keys.
      */
+    @Override
     public Set<K> keySet() {
         if (keySet == null) {
             keySet = new AbstractSet<>() {
@@ -355,14 +368,17 @@ public abstract class AbstractMap<K, V> implements Map<K, V> {
                     return new Iterator<>() {
                         Iterator<Map.Entry<K, V>> setIterator = entrySet().iterator();
 
+                        @Override
                         public boolean hasNext() {
                             return setIterator.hasNext();
                         }
 
+                        @Override
                         public K next() {
                             return setIterator.next().getKey();
                         }
 
+                        @Override
                         public void remove() {
                             setIterator.remove();
                         }
@@ -379,6 +395,7 @@ public abstract class AbstractMap<K, V> implements Map<K, V> {
      * <p>
      * This base implementation throws {@code UnsupportedOperationException}.
      */
+    @Override
     public V put(K key, V value) {
         throw new UnsupportedOperationException();
     }
@@ -390,6 +407,7 @@ public abstract class AbstractMap<K, V> implements Map<K, V> {
      * This implementation iterates through {@code map}'s entry set, calling
      * {@code put()} for each.
      */
+    @Override
     public void putAll(Map<? extends K, ? extends V> map) {
         for (Map.Entry<? extends K, ? extends V> entry : map.entrySet()) {
             put(entry.getKey(), entry.getValue());
@@ -403,6 +421,7 @@ public abstract class AbstractMap<K, V> implements Map<K, V> {
      * This implementation iterates its entry set, removing the entry with
      * a key that {@code key} equals.
      */
+    @Override
     public V remove(Object key) {
         Iterator<Map.Entry<K, V>> it = entrySet().iterator();
         if (key != null) {
@@ -431,6 +450,7 @@ public abstract class AbstractMap<K, V> implements Map<K, V> {
      * <p>
      * This implementation returns its entry set's size.
      */
+    @Override
     public int size() {
         return entrySet().size();
     }
@@ -482,6 +502,7 @@ public abstract class AbstractMap<K, V> implements Map<K, V> {
      * This implementation returns a view that calls through this to map. Its
      * iterator transforms this map's entry set iterator to return values.
      */
+    @Override
     public Collection<V> values() {
         if (valuesCollection == null) {
             valuesCollection = new AbstractCollection<>() {
@@ -500,14 +521,17 @@ public abstract class AbstractMap<K, V> implements Map<K, V> {
                     return new Iterator<>() {
                         Iterator<Map.Entry<K, V>> setIterator = entrySet().iterator();
 
+                        @Override
                         public boolean hasNext() {
                             return setIterator.hasNext();
                         }
 
+                        @Override
                         public V next() {
                             return setIterator.next().getValue();
                         }
 
+                        @Override
                         public void remove() {
                             setIterator.remove();
                         }

--- a/bundles/org.jupnp/src/main/java/org/jupnp/Main.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/Main.java
@@ -31,38 +31,47 @@ public class Main {
         // UPnP discovery is asynchronous, we need a callback
         RegistryListener listener = new RegistryListener() {
 
+            @Override
             public void remoteDeviceDiscoveryStarted(Registry registry, RemoteDevice device) {
                 System.out.println("Discovery started: " + device.getDisplayString());
             }
 
+            @Override
             public void remoteDeviceDiscoveryFailed(Registry registry, RemoteDevice device, Exception ex) {
                 System.out.println("Discovery failed: " + device.getDisplayString() + " => " + ex);
             }
 
+            @Override
             public void remoteDeviceAdded(Registry registry, RemoteDevice device) {
                 System.out.println("Remote device available: " + device.getDisplayString());
             }
 
+            @Override
             public void remoteDeviceUpdated(Registry registry, RemoteDevice device) {
                 System.out.println("Remote device updated: " + device.getDisplayString());
             }
 
+            @Override
             public void remoteDeviceRemoved(Registry registry, RemoteDevice device) {
                 System.out.println("Remote device removed: " + device.getDisplayString());
             }
 
+            @Override
             public void localDeviceAdded(Registry registry, LocalDevice device) {
                 System.out.println("Local device added: " + device.getDisplayString());
             }
 
+            @Override
             public void localDeviceRemoved(Registry registry, LocalDevice device) {
                 System.out.println("Local device removed: " + device.getDisplayString());
             }
 
+            @Override
             public void beforeShutdown(Registry registry) {
                 System.out.println("Before shutdown, the registry has devices: " + registry.getDevices().size());
             }
 
+            @Override
             public void afterShutdown() {
                 System.out.println("Shutdown of registry complete!");
             }

--- a/bundles/org.jupnp/src/main/java/org/jupnp/UpnpServiceImpl.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/UpnpServiceImpl.java
@@ -165,26 +165,32 @@ public class UpnpServiceImpl implements UpnpService {
         return new ControlPointImpl(getConfiguration(), protocolFactory, registry);
     }
 
+    @Override
     public UpnpServiceConfiguration getConfiguration() {
         return configuration;
     }
 
+    @Override
     public ControlPoint getControlPoint() {
         return controlPoint;
     }
 
+    @Override
     public ProtocolFactory getProtocolFactory() {
         return protocolFactory;
     }
 
+    @Override
     public Registry getRegistry() {
         return registry;
     }
 
+    @Override
     public Router getRouter() {
         return router;
     }
 
+    @Override
     public synchronized void shutdown() {
         shutdown(false);
     }
@@ -255,6 +261,7 @@ public class UpnpServiceImpl implements UpnpService {
         scheduledFuture = scheduledExecutorService.schedule(startup, msDelay, TimeUnit.MILLISECONDS);
     }
 
+    @Override
     public void startup() {
         synchronized (lock) {
             if (!isRunning) {

--- a/bundles/org.jupnp/src/main/java/org/jupnp/binding/annotations/AnnotationLocalServiceBinder.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/binding/annotations/AnnotationLocalServiceBinder.java
@@ -58,6 +58,7 @@ public class AnnotationLocalServiceBinder implements LocalServiceBinder {
 
     private Logger log = LoggerFactory.getLogger(AnnotationLocalServiceBinder.class);
 
+    @Override
     public LocalService read(Class<?> clazz) throws LocalServiceBindingException {
         log.trace("Reading and binding annotations of service implementation class: {}", clazz);
 
@@ -86,6 +87,7 @@ public class AnnotationLocalServiceBinder implements LocalServiceBinder {
         }
     }
 
+    @Override
     public LocalService read(Class<?> clazz, ServiceId id, ServiceType type, boolean supportsQueryStateVariables,
             Class[] stringConvertibleTypes) throws LocalServiceBindingException {
         return read(clazz, id, type, supportsQueryStateVariables, new HashSet<>(Arrays.asList(stringConvertibleTypes)));

--- a/bundles/org.jupnp/src/main/java/org/jupnp/binding/xml/UDA10DeviceDescriptorBinderImpl.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/binding/xml/UDA10DeviceDescriptorBinderImpl.java
@@ -71,6 +71,7 @@ public class UDA10DeviceDescriptorBinderImpl implements DeviceDescriptorBinder, 
 
     private final Logger log = LoggerFactory.getLogger(DeviceDescriptorBinder.class);
 
+    @Override
     public <D extends Device> D describe(D undescribedDevice, String descriptorXml)
             throws DescriptorBindingException, ValidationException {
 
@@ -110,6 +111,7 @@ public class UDA10DeviceDescriptorBinderImpl implements DeviceDescriptorBinder, 
         }
     }
 
+    @Override
     public <D extends Device> D describe(D undescribedDevice, Document dom)
             throws DescriptorBindingException, ValidationException {
         try {
@@ -391,6 +393,7 @@ public class UDA10DeviceDescriptorBinderImpl implements DeviceDescriptorBinder, 
         }
     }
 
+    @Override
     public String generate(Device deviceModel, RemoteClientInfo info, Namespace namespace)
             throws DescriptorBindingException {
         try {
@@ -403,6 +406,7 @@ public class UDA10DeviceDescriptorBinderImpl implements DeviceDescriptorBinder, 
         }
     }
 
+    @Override
     public Document buildDOM(Device deviceModel, RemoteClientInfo info, Namespace namespace)
             throws DescriptorBindingException {
 
@@ -565,14 +569,17 @@ public class UDA10DeviceDescriptorBinderImpl implements DeviceDescriptorBinder, 
         }
     }
 
+    @Override
     public void warning(SAXParseException e) throws SAXException {
         log.warn(e.toString());
     }
 
+    @Override
     public void error(SAXParseException e) throws SAXException {
         throw e;
     }
 
+    @Override
     public void fatalError(SAXParseException e) throws SAXException {
         throw e;
     }

--- a/bundles/org.jupnp/src/main/java/org/jupnp/binding/xml/UDA10ServiceDescriptorBinderImpl.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/binding/xml/UDA10ServiceDescriptorBinderImpl.java
@@ -66,6 +66,7 @@ public class UDA10ServiceDescriptorBinderImpl implements ServiceDescriptorBinder
 
     private final Logger log = LoggerFactory.getLogger(ServiceDescriptorBinder.class);
 
+    @Override
     public <S extends Service> S describe(S undescribedService, String descriptorXml)
             throws DescriptorBindingException, ValidationException {
         if (descriptorXml == null || descriptorXml.isEmpty()) {
@@ -94,6 +95,7 @@ public class UDA10ServiceDescriptorBinderImpl implements ServiceDescriptorBinder
         }
     }
 
+    @Override
     public <S extends Service> S describe(S undescribedService, Document dom)
             throws DescriptorBindingException, ValidationException {
         try {
@@ -335,6 +337,7 @@ public class UDA10ServiceDescriptorBinderImpl implements ServiceDescriptorBinder
         }
     }
 
+    @Override
     public String generate(Service service) throws DescriptorBindingException {
         try {
             log.trace("Generating XML descriptor from service model: {}", service);
@@ -346,6 +349,7 @@ public class UDA10ServiceDescriptorBinderImpl implements ServiceDescriptorBinder
         }
     }
 
+    @Override
     public Document buildDOM(Service service) throws DescriptorBindingException {
 
         try {
@@ -482,14 +486,17 @@ public class UDA10ServiceDescriptorBinderImpl implements ServiceDescriptorBinder
         }
     }
 
+    @Override
     public void warning(SAXParseException e) throws SAXException {
         log.warn(e.toString());
     }
 
+    @Override
     public void error(SAXParseException e) throws SAXException {
         throw e;
     }
 
+    @Override
     public void fatalError(SAXParseException e) throws SAXException {
         throw e;
     }

--- a/bundles/org.jupnp/src/main/java/org/jupnp/controlpoint/ActionCallback.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/controlpoint/ActionCallback.java
@@ -113,6 +113,7 @@ public abstract class ActionCallback implements Runnable {
         return this;
     }
 
+    @Override
     public void run() {
         Service service = actionInvocation.getAction().getService();
 

--- a/bundles/org.jupnp/src/main/java/org/jupnp/controlpoint/ControlPointImpl.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/controlpoint/ControlPointImpl.java
@@ -58,14 +58,17 @@ public class ControlPointImpl implements ControlPoint {
         this.registry = registry;
     }
 
+    @Override
     public UpnpServiceConfiguration getConfiguration() {
         return configuration;
     }
 
+    @Override
     public ProtocolFactory getProtocolFactory() {
         return protocolFactory;
     }
 
+    @Override
     public Registry getRegistry() {
         return registry;
     }
@@ -74,18 +77,22 @@ public class ControlPointImpl implements ControlPoint {
         search(search.getSearchType(), search.getMxSeconds());
     }
 
+    @Override
     public void search() {
         search(new STAllHeader(), MXHeader.DEFAULT_VALUE);
     }
 
+    @Override
     public void search(UpnpHeader searchType) {
         search(searchType, MXHeader.DEFAULT_VALUE);
     }
 
+    @Override
     public void search(int mxSeconds) {
         search(new STAllHeader(), mxSeconds);
     }
 
+    @Override
     public void search(UpnpHeader searchType, int mxSeconds) {
         log.trace("Sending asynchronous search for: {}", searchType.getString());
         getConfiguration().getAsyncProtocolExecutor()
@@ -96,6 +103,7 @@ public class ControlPointImpl implements ControlPoint {
         execute(executeAction.getCallback());
     }
 
+    @Override
     public Future execute(ActionCallback callback) {
         log.trace("Invoking action in background: {}", callback);
         callback.setControlPoint(this);
@@ -103,6 +111,7 @@ public class ControlPointImpl implements ControlPoint {
         return executor.submit(callback);
     }
 
+    @Override
     public void execute(SubscriptionCallback callback) {
         log.trace("Invoking subscription in background: {}", callback);
         callback.setControlPoint(this);

--- a/bundles/org.jupnp/src/main/java/org/jupnp/controlpoint/SubscriptionCallback.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/controlpoint/SubscriptionCallback.java
@@ -110,6 +110,7 @@ public abstract class SubscriptionCallback implements Runnable {
         this.subscription = subscription;
     }
 
+    @Override
     public synchronized void run() {
         if (getControlPoint() == null) {
             throw new IllegalStateException("Callback must be executed through ControlPoint");
@@ -145,6 +146,7 @@ public abstract class SubscriptionCallback implements Runnable {
                     }
                 }
 
+                @Override
                 public void established() {
                     synchronized (SubscriptionCallback.this) {
                         SubscriptionCallback.this.setSubscription(this);
@@ -152,6 +154,7 @@ public abstract class SubscriptionCallback implements Runnable {
                     }
                 }
 
+                @Override
                 public void ended(CancelReason reason) {
                     synchronized (SubscriptionCallback.this) {
                         SubscriptionCallback.this.setSubscription(null);
@@ -159,6 +162,7 @@ public abstract class SubscriptionCallback implements Runnable {
                     }
                 }
 
+                @Override
                 public void eventReceived() {
                     synchronized (SubscriptionCallback.this) {
                         log.trace("Local service state updated, notifying callback, sequence is: {}",
@@ -195,6 +199,7 @@ public abstract class SubscriptionCallback implements Runnable {
     private void establishRemoteSubscription(RemoteService service) {
         RemoteGENASubscription remoteSubscription = new RemoteGENASubscription(service, requestedDurationSeconds) {
 
+            @Override
             public void failed(UpnpResponse responseStatus) {
                 synchronized (SubscriptionCallback.this) {
                     SubscriptionCallback.this.setSubscription(null);
@@ -202,6 +207,7 @@ public abstract class SubscriptionCallback implements Runnable {
                 }
             }
 
+            @Override
             public void established() {
                 synchronized (SubscriptionCallback.this) {
                     SubscriptionCallback.this.setSubscription(this);
@@ -209,6 +215,7 @@ public abstract class SubscriptionCallback implements Runnable {
                 }
             }
 
+            @Override
             public void ended(CancelReason reason, UpnpResponse responseStatus) {
                 synchronized (SubscriptionCallback.this) {
                     SubscriptionCallback.this.setSubscription(null);
@@ -216,18 +223,21 @@ public abstract class SubscriptionCallback implements Runnable {
                 }
             }
 
+            @Override
             public void eventReceived() {
                 synchronized (SubscriptionCallback.this) {
                     SubscriptionCallback.this.eventReceived(this);
                 }
             }
 
+            @Override
             public void eventsMissed(int numberOfMissedEvents) {
                 synchronized (SubscriptionCallback.this) {
                     SubscriptionCallback.this.eventsMissed(this, numberOfMissedEvents);
                 }
             }
 
+            @Override
             public void invalidMessage(UnsupportedDataException ex) {
                 synchronized (SubscriptionCallback.this) {
                     SubscriptionCallback.this.invalidMessage(this, ex);

--- a/bundles/org.jupnp/src/main/java/org/jupnp/http/Headers.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/http/Headers.java
@@ -80,34 +80,42 @@ public class Headers implements Map<String, List<String>> {
         this.normalizeHeaders = normalizeHeaders;
     }
 
+    @Override
     public int size() {
         return map.size();
     }
 
+    @Override
     public boolean isEmpty() {
         return map.isEmpty();
     }
 
+    @Override
     public boolean containsKey(Object key) {
         return key != null && key instanceof String && map.containsKey(normalize((String) key));
     }
 
+    @Override
     public boolean containsValue(Object value) {
         return map.containsValue(value);
     }
 
+    @Override
     public List<String> get(Object key) {
         return map.get(normalize((String) key));
     }
 
+    @Override
     public List<String> put(String key, List<String> value) {
         return map.put(normalize(key), value);
     }
 
+    @Override
     public List<String> remove(Object key) {
         return map.remove(normalize((String) key));
     }
 
+    @Override
     public void putAll(Map<? extends String, ? extends List<String>> t) {
         // Enforce key normalization!
         for (Entry<? extends String, ? extends List<String>> entry : t.entrySet()) {
@@ -115,18 +123,22 @@ public class Headers implements Map<String, List<String>> {
         }
     }
 
+    @Override
     public void clear() {
         map.clear();
     }
 
+    @Override
     public Set<String> keySet() {
         return map.keySet();
     }
 
+    @Override
     public Collection<List<String>> values() {
         return map.values();
     }
 
+    @Override
     public Set<Map.Entry<String, List<String>>> entrySet() {
         return map.entrySet();
     }

--- a/bundles/org.jupnp/src/main/java/org/jupnp/model/DefaultServiceManager.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/model/DefaultServiceManager.java
@@ -92,10 +92,12 @@ public class DefaultServiceManager<T> implements ServiceManager<T> {
         return 500;
     }
 
+    @Override
     public LocalService<T> getService() {
         return service;
     }
 
+    @Override
     public T getImplementation() {
         lock();
         try {
@@ -108,6 +110,7 @@ public class DefaultServiceManager<T> implements ServiceManager<T> {
         }
     }
 
+    @Override
     public PropertyChangeSupport getPropertyChangeSupport() {
         lock();
         try {
@@ -120,6 +123,7 @@ public class DefaultServiceManager<T> implements ServiceManager<T> {
         }
     }
 
+    @Override
     public void execute(Command<T> cmd) throws Exception {
         lock();
         try {
@@ -239,6 +243,7 @@ public class DefaultServiceManager<T> implements ServiceManager<T> {
 
     protected class DefaultPropertyChangeListener implements PropertyChangeListener {
 
+        @Override
         public void propertyChange(PropertyChangeEvent e) {
             log.trace("Property change event on local service: {}", e.getPropertyName());
 

--- a/bundles/org.jupnp/src/main/java/org/jupnp/model/action/AbstractActionExecutor.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/model/action/AbstractActionExecutor.java
@@ -55,6 +55,7 @@ public abstract class AbstractActionExecutor implements ActionExecutor {
     /**
      * Obtains the service implementation instance from the {@link org.jupnp.model.ServiceManager}, handles exceptions.
      */
+    @Override
     public void execute(final ActionInvocation<LocalService> actionInvocation) {
 
         log.trace("Invoking on local service: {}", actionInvocation);
@@ -68,6 +69,7 @@ public abstract class AbstractActionExecutor implements ActionExecutor {
             }
 
             service.getManager().execute(new Command() {
+                @Override
                 public void execute(ServiceManager serviceManager) throws Exception {
                     AbstractActionExecutor.this.execute(actionInvocation, serviceManager.getImplementation());
                 }

--- a/bundles/org.jupnp/src/main/java/org/jupnp/model/gena/LocalGENASubscription.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/model/gena/LocalGENASubscription.java
@@ -130,6 +130,7 @@ public abstract class LocalGENASubscription extends GENASubscription<LocalServic
      * Moderates {@link org.jupnp.model.ServiceManager#EVENTED_STATE_VARIABLES} events and state variable
      * values, calls {@link #eventReceived()}.
      */
+    @Override
     public synchronized void propertyChange(PropertyChangeEvent e) {
         if (!e.getPropertyName().equals(ServiceManager.EVENTED_STATE_VARIABLES)) {
             return;

--- a/bundles/org.jupnp/src/main/java/org/jupnp/model/message/control/IncomingActionRequestMessage.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/model/message/control/IncomingActionRequestMessage.java
@@ -64,6 +64,7 @@ public class IncomingActionRequestMessage extends StreamRequestMessage implement
         return action;
     }
 
+    @Override
     public String getActionNamespace() {
         return actionNamespace;
     }

--- a/bundles/org.jupnp/src/main/java/org/jupnp/model/message/control/IncomingActionResponseMessage.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/model/message/control/IncomingActionResponseMessage.java
@@ -31,6 +31,7 @@ public class IncomingActionResponseMessage extends StreamResponseMessage impleme
         super(operation);
     }
 
+    @Override
     public String getActionNamespace() {
         return null; // TODO: We _could_ read this in SOAPActionProcessor and set it when we receive a response but why?
     }

--- a/bundles/org.jupnp/src/main/java/org/jupnp/model/message/control/OutgoingActionRequestMessage.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/model/message/control/OutgoingActionRequestMessage.java
@@ -83,6 +83,7 @@ public class OutgoingActionRequestMessage extends StreamRequestMessage implement
         }
     }
 
+    @Override
     public String getActionNamespace() {
         return actionNamespace;
     }

--- a/bundles/org.jupnp/src/main/java/org/jupnp/model/message/control/OutgoingActionResponseMessage.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/model/message/control/OutgoingActionResponseMessage.java
@@ -61,6 +61,7 @@ public class OutgoingActionResponseMessage extends StreamResponseMessage impleme
         getHeaders().add(UpnpHeader.Type.EXT, new EXTHeader());
     }
 
+    @Override
     public String getActionNamespace() {
         return actionNamespace;
     }

--- a/bundles/org.jupnp/src/main/java/org/jupnp/model/message/header/CallbackHeader.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/model/message/header/CallbackHeader.java
@@ -45,6 +45,7 @@ public class CallbackHeader extends UpnpHeader<List<URL>> {
         getValue().add(url);
     }
 
+    @Override
     public void setString(String s) throws InvalidHeaderException {
 
         if (s.isEmpty()) {
@@ -95,6 +96,7 @@ public class CallbackHeader extends UpnpHeader<List<URL>> {
         }
     }
 
+    @Override
     public String getString() {
         StringBuilder s = new StringBuilder();
         for (URL url : getValue()) {

--- a/bundles/org.jupnp/src/main/java/org/jupnp/model/message/header/ContentRangeHeader.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/model/message/header/ContentRangeHeader.java
@@ -38,6 +38,7 @@ public class ContentRangeHeader extends UpnpHeader<BytesRange> {
         setString(s);
     }
 
+    @Override
     public void setString(String s) throws InvalidHeaderException {
         try {
             setValue(BytesRange.valueOf(s, PREFIX));
@@ -46,6 +47,7 @@ public class ContentRangeHeader extends UpnpHeader<BytesRange> {
         }
     }
 
+    @Override
     public String getString() {
         return getValue().getString(true, PREFIX);
     }

--- a/bundles/org.jupnp/src/main/java/org/jupnp/model/message/header/ContentTypeHeader.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/model/message/header/ContentTypeHeader.java
@@ -37,10 +37,12 @@ public class ContentTypeHeader extends UpnpHeader<MimeType> {
         setString(s);
     }
 
+    @Override
     public void setString(String s) throws InvalidHeaderException {
         setValue(MimeType.valueOf(s));
     }
 
+    @Override
     public String getString() {
         return getValue().toString();
     }

--- a/bundles/org.jupnp/src/main/java/org/jupnp/model/message/header/DeviceTypeHeader.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/model/message/header/DeviceTypeHeader.java
@@ -35,6 +35,7 @@ public class DeviceTypeHeader extends UpnpHeader<DeviceType> {
         setValue(value);
     }
 
+    @Override
     public void setString(String s) throws InvalidHeaderException {
         try {
             setValue(DeviceType.valueOf(s));
@@ -43,6 +44,7 @@ public class DeviceTypeHeader extends UpnpHeader<DeviceType> {
         }
     }
 
+    @Override
     public String getString() {
         return getValue().toString();
     }

--- a/bundles/org.jupnp/src/main/java/org/jupnp/model/message/header/DeviceUSNHeader.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/model/message/header/DeviceUSNHeader.java
@@ -35,6 +35,7 @@ public class DeviceUSNHeader extends UpnpHeader<NamedDeviceType> {
         setValue(value);
     }
 
+    @Override
     public void setString(String s) throws InvalidHeaderException {
         try {
             setValue(NamedDeviceType.valueOf(s));
@@ -43,6 +44,7 @@ public class DeviceUSNHeader extends UpnpHeader<NamedDeviceType> {
         }
     }
 
+    @Override
     public String getString() {
         return getValue().toString();
     }

--- a/bundles/org.jupnp/src/main/java/org/jupnp/model/message/header/EXTHeader.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/model/message/header/EXTHeader.java
@@ -27,12 +27,14 @@ public class EXTHeader extends UpnpHeader<String> {
         setValue(DEFAULT_VALUE);
     }
 
+    @Override
     public void setString(String s) throws InvalidHeaderException {
         if (s != null && !s.isEmpty()) {
             throw new InvalidHeaderException("Invalid EXT header, it has no value: " + s);
         }
     }
 
+    @Override
     public String getString() {
         return getValue();
     }

--- a/bundles/org.jupnp/src/main/java/org/jupnp/model/message/header/EventSequenceHeader.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/model/message/header/EventSequenceHeader.java
@@ -29,6 +29,7 @@ public class EventSequenceHeader extends UpnpHeader<UnsignedIntegerFourBytes> {
         setValue(new UnsignedIntegerFourBytes(value));
     }
 
+    @Override
     public void setString(String s) throws InvalidHeaderException {
 
         // Cut off leading zeros
@@ -45,6 +46,7 @@ public class EventSequenceHeader extends UpnpHeader<UnsignedIntegerFourBytes> {
         }
     }
 
+    @Override
     public String getString() {
         return getValue().toString();
     }

--- a/bundles/org.jupnp/src/main/java/org/jupnp/model/message/header/HostHeader.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/model/message/header/HostHeader.java
@@ -38,6 +38,7 @@ public class HostHeader extends UpnpHeader<HostPort> {
         setValue(new HostPort(host, port));
     }
 
+    @Override
     public void setString(String s) throws InvalidHeaderException {
         // UDA 1.1/1.0 section 1.2.2
         if (s.contains(":")) {
@@ -56,6 +57,7 @@ public class HostHeader extends UpnpHeader<HostPort> {
         }
     }
 
+    @Override
     public String getString() {
         return getValue().toString();
     }

--- a/bundles/org.jupnp/src/main/java/org/jupnp/model/message/header/InterfaceMacHeader.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/model/message/header/InterfaceMacHeader.java
@@ -35,6 +35,7 @@ public class InterfaceMacHeader extends UpnpHeader<byte[]> {
         setString(s);
     }
 
+    @Override
     public void setString(String s) throws InvalidHeaderException {
         byte[] bytes = HexBin.stringToBytes(s, ":");
         setValue(bytes);
@@ -43,6 +44,7 @@ public class InterfaceMacHeader extends UpnpHeader<byte[]> {
         }
     }
 
+    @Override
     public String getString() {
         return HexBin.bytesToString(getValue(), ":");
     }

--- a/bundles/org.jupnp/src/main/java/org/jupnp/model/message/header/LocationHeader.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/model/message/header/LocationHeader.java
@@ -40,6 +40,7 @@ public class LocationHeader extends UpnpHeader<URL> {
         setString(s);
     }
 
+    @Override
     public void setString(String s) throws InvalidHeaderException {
         try {
             URL url = new URL(s);
@@ -49,6 +50,7 @@ public class LocationHeader extends UpnpHeader<URL> {
         }
     }
 
+    @Override
     public String getString() {
         return getValue().toString();
     }

--- a/bundles/org.jupnp/src/main/java/org/jupnp/model/message/header/MANHeader.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/model/message/header/MANHeader.java
@@ -40,6 +40,7 @@ public class MANHeader extends UpnpHeader<String> {
         this.namespace = namespace;
     }
 
+    @Override
     public void setString(String s) throws InvalidHeaderException {
 
         Matcher matcher = PATTERN.matcher(s);
@@ -60,6 +61,7 @@ public class MANHeader extends UpnpHeader<String> {
         }
     }
 
+    @Override
     public String getString() {
         if (getValue() == null) {
             return null;

--- a/bundles/org.jupnp/src/main/java/org/jupnp/model/message/header/MXHeader.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/model/message/header/MXHeader.java
@@ -34,6 +34,7 @@ public class MXHeader extends UpnpHeader<Integer> {
         setValue(delayInSeconds);
     }
 
+    @Override
     public void setString(String s) throws InvalidHeaderException {
         int value;
         try {
@@ -51,6 +52,7 @@ public class MXHeader extends UpnpHeader<Integer> {
         }
     }
 
+    @Override
     public String getString() {
         return getValue().toString();
     }

--- a/bundles/org.jupnp/src/main/java/org/jupnp/model/message/header/MaxAgeHeader.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/model/message/header/MaxAgeHeader.java
@@ -37,6 +37,7 @@ public class MaxAgeHeader extends UpnpHeader<Integer> {
         setValue(Constants.MIN_ADVERTISEMENT_AGE_SECONDS);
     }
 
+    @Override
     public void setString(String s) throws InvalidHeaderException {
 
         Matcher matcher = MAX_AGE_REGEX.matcher(s.toLowerCase(Locale.ENGLISH));
@@ -48,6 +49,7 @@ public class MaxAgeHeader extends UpnpHeader<Integer> {
         setValue(maxAge);
     }
 
+    @Override
     public String getString() {
         return "max-age=" + getValue().toString();
     }

--- a/bundles/org.jupnp/src/main/java/org/jupnp/model/message/header/NTEventHeader.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/model/message/header/NTEventHeader.java
@@ -26,12 +26,14 @@ public class NTEventHeader extends UpnpHeader<String> {
         setValue("upnp:event");
     }
 
+    @Override
     public void setString(String s) throws InvalidHeaderException {
         if (!s.toLowerCase(Locale.ENGLISH).equals(getValue())) {
             throw new InvalidHeaderException("Invalid event NT header value: " + s);
         }
     }
 
+    @Override
     public String getString() {
         return getValue();
     }

--- a/bundles/org.jupnp/src/main/java/org/jupnp/model/message/header/NTSHeader.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/model/message/header/NTSHeader.java
@@ -29,6 +29,7 @@ public class NTSHeader extends UpnpHeader<NotificationSubtype> {
         setValue(type);
     }
 
+    @Override
     public void setString(String s) throws InvalidHeaderException {
         for (NotificationSubtype type : NotificationSubtype.values()) {
             if (s.equals(type.getHeaderString())) {
@@ -41,6 +42,7 @@ public class NTSHeader extends UpnpHeader<NotificationSubtype> {
         }
     }
 
+    @Override
     public String getString() {
         return getValue().getHeaderString();
     }

--- a/bundles/org.jupnp/src/main/java/org/jupnp/model/message/header/PragmaHeader.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/model/message/header/PragmaHeader.java
@@ -36,6 +36,7 @@ public class PragmaHeader extends UpnpHeader<PragmaType> {
         setString(s);
     }
 
+    @Override
     public void setString(String s) throws InvalidHeaderException {
         try {
             setValue(PragmaType.valueOf(s));
@@ -44,6 +45,7 @@ public class PragmaHeader extends UpnpHeader<PragmaType> {
         }
     }
 
+    @Override
     public String getString() {
         return getValue().getString();
     }

--- a/bundles/org.jupnp/src/main/java/org/jupnp/model/message/header/RangeHeader.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/model/message/header/RangeHeader.java
@@ -36,6 +36,7 @@ public class RangeHeader extends UpnpHeader<BytesRange> {
         setString(s);
     }
 
+    @Override
     public void setString(String s) throws InvalidHeaderException {
         try {
             setValue(BytesRange.valueOf(s));
@@ -44,6 +45,7 @@ public class RangeHeader extends UpnpHeader<BytesRange> {
         }
     }
 
+    @Override
     public String getString() {
         return getValue().getString();
     }

--- a/bundles/org.jupnp/src/main/java/org/jupnp/model/message/header/RootDeviceHeader.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/model/message/header/RootDeviceHeader.java
@@ -26,12 +26,14 @@ public class RootDeviceHeader extends UpnpHeader<String> {
         setValue("upnp:rootdevice");
     }
 
+    @Override
     public void setString(String s) throws InvalidHeaderException {
         if (!s.toLowerCase(Locale.ENGLISH).equals(getValue())) {
             throw new InvalidHeaderException("Invalid root device NT header value: " + s);
         }
     }
 
+    @Override
     public String getString() {
         return getValue();
     }

--- a/bundles/org.jupnp/src/main/java/org/jupnp/model/message/header/STAllHeader.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/model/message/header/STAllHeader.java
@@ -26,12 +26,14 @@ public class STAllHeader extends UpnpHeader<NotificationSubtype> {
         setValue(NotificationSubtype.ALL);
     }
 
+    @Override
     public void setString(String s) throws InvalidHeaderException {
         if (!s.equals(NotificationSubtype.ALL.getHeaderString())) {
             throw new InvalidHeaderException("Invalid ST header value (not " + NotificationSubtype.ALL + "): " + s);
         }
     }
 
+    @Override
     public String getString() {
         return getValue().getHeaderString();
     }

--- a/bundles/org.jupnp/src/main/java/org/jupnp/model/message/header/ServerHeader.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/model/message/header/ServerHeader.java
@@ -30,6 +30,7 @@ public class ServerHeader extends UpnpHeader<ServerClientTokens> {
         setValue(tokens);
     }
 
+    @Override
     public void setString(String s) throws InvalidHeaderException {
         // TODO: This parsing is not as robust as I'd like, probably should use regexs instead
 
@@ -122,6 +123,7 @@ public class ServerHeader extends UpnpHeader<ServerClientTokens> {
         setValue(serverClientTokens);
     }
 
+    @Override
     public String getString() {
         return getValue().getHttpToken();
     }

--- a/bundles/org.jupnp/src/main/java/org/jupnp/model/message/header/ServiceTypeHeader.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/model/message/header/ServiceTypeHeader.java
@@ -35,6 +35,7 @@ public class ServiceTypeHeader extends UpnpHeader<ServiceType> {
         setValue(value);
     }
 
+    @Override
     public void setString(String s) throws InvalidHeaderException {
         try {
             setValue(ServiceType.valueOf(s));
@@ -43,6 +44,7 @@ public class ServiceTypeHeader extends UpnpHeader<ServiceType> {
         }
     }
 
+    @Override
     public String getString() {
         return getValue().toString();
     }

--- a/bundles/org.jupnp/src/main/java/org/jupnp/model/message/header/ServiceUSNHeader.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/model/message/header/ServiceUSNHeader.java
@@ -35,6 +35,7 @@ public class ServiceUSNHeader extends UpnpHeader<NamedServiceType> {
         setValue(value);
     }
 
+    @Override
     public void setString(String s) throws InvalidHeaderException {
         try {
             setValue(NamedServiceType.valueOf(s));
@@ -43,6 +44,7 @@ public class ServiceUSNHeader extends UpnpHeader<NamedServiceType> {
         }
     }
 
+    @Override
     public String getString() {
         return getValue().toString();
     }

--- a/bundles/org.jupnp/src/main/java/org/jupnp/model/message/header/SoapActionHeader.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/model/message/header/SoapActionHeader.java
@@ -39,6 +39,7 @@ public class SoapActionHeader extends UpnpHeader<SoapActionType> {
         setString(s);
     }
 
+    @Override
     public void setString(String s) throws InvalidHeaderException {
         try {
             if (!s.startsWith("\"") && s.endsWith("\"")) {
@@ -52,6 +53,7 @@ public class SoapActionHeader extends UpnpHeader<SoapActionType> {
         }
     }
 
+    @Override
     public String getString() {
         return "\"" + getValue().toString() + "\"";
     }

--- a/bundles/org.jupnp/src/main/java/org/jupnp/model/message/header/SubscriptionIdHeader.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/model/message/header/SubscriptionIdHeader.java
@@ -29,6 +29,7 @@ public class SubscriptionIdHeader extends UpnpHeader<String> {
         setValue(value);
     }
 
+    @Override
     public void setString(String s) throws InvalidHeaderException {
         if (!s.startsWith(PREFIX)) {
             throw new InvalidHeaderException(
@@ -37,6 +38,7 @@ public class SubscriptionIdHeader extends UpnpHeader<String> {
         setValue(s);
     }
 
+    @Override
     public String getString() {
         return getValue();
     }

--- a/bundles/org.jupnp/src/main/java/org/jupnp/model/message/header/TimeoutHeader.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/model/message/header/TimeoutHeader.java
@@ -45,6 +45,7 @@ public class TimeoutHeader extends UpnpHeader<Integer> {
         setValue(timeoutSeconds);
     }
 
+    @Override
     public void setString(String s) throws InvalidHeaderException {
 
         Matcher matcher = PATTERN.matcher(s);
@@ -59,6 +60,7 @@ public class TimeoutHeader extends UpnpHeader<Integer> {
         }
     }
 
+    @Override
     public String getString() {
         return "Second-" + (getValue().equals(INFINITE_VALUE) ? "infinite" : getValue());
     }

--- a/bundles/org.jupnp/src/main/java/org/jupnp/model/message/header/UDNHeader.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/model/message/header/UDNHeader.java
@@ -29,6 +29,7 @@ public class UDNHeader extends UpnpHeader<UDN> {
         setValue(udn);
     }
 
+    @Override
     public void setString(String s) throws InvalidHeaderException {
         if (!s.startsWith(UDN.PREFIX)) {
             throw new InvalidHeaderException("Invalid UDA header value, must start with '" + UDN.PREFIX + "': " + s);
@@ -42,6 +43,7 @@ public class UDNHeader extends UpnpHeader<UDN> {
         setValue(udn);
     }
 
+    @Override
     public String getString() {
         return getValue().toString();
     }

--- a/bundles/org.jupnp/src/main/java/org/jupnp/model/message/header/USNRootDeviceHeader.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/model/message/header/USNRootDeviceHeader.java
@@ -31,6 +31,7 @@ public class USNRootDeviceHeader extends UpnpHeader<UDN> {
         setValue(udn);
     }
 
+    @Override
     public void setString(String s) throws InvalidHeaderException {
         if (!s.startsWith(UDN.PREFIX) || !s.endsWith(ROOT_DEVICE_SUFFIX)) {
             throw new InvalidHeaderException("Invalid root device USN header value, must start with '" + UDN.PREFIX
@@ -40,6 +41,7 @@ public class USNRootDeviceHeader extends UpnpHeader<UDN> {
         setValue(udn);
     }
 
+    @Override
     public String getString() {
         return getValue().toString() + ROOT_DEVICE_SUFFIX;
     }

--- a/bundles/org.jupnp/src/main/java/org/jupnp/model/meta/Action.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/model/meta/Action.java
@@ -138,6 +138,7 @@ public class Action<S extends Service> implements Validatable {
                 + (getArguments() != null ? getArguments().length : "NO ARGS") + ") " + getName();
     }
 
+    @Override
     public List<ValidationError> validate() {
         List<ValidationError> errors = new ArrayList<>();
 

--- a/bundles/org.jupnp/src/main/java/org/jupnp/model/meta/ActionArgument.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/model/meta/ActionArgument.java
@@ -117,6 +117,7 @@ public class ActionArgument<S extends Service> implements Validatable {
         return getAction().getService().getDatatype(this);
     }
 
+    @Override
     public List<ValidationError> validate() {
         List<ValidationError> errors = new ArrayList<>();
 

--- a/bundles/org.jupnp/src/main/java/org/jupnp/model/meta/Device.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/model/meta/Device.java
@@ -383,6 +383,7 @@ public abstract class Device<DI extends DeviceIdentity, D extends Device, S exte
         return sb.toString();
     }
 
+    @Override
     public List<ValidationError> validate() {
         List<ValidationError> errors = new ArrayList<>();
 

--- a/bundles/org.jupnp/src/main/java/org/jupnp/model/meta/DeviceDetails.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/model/meta/DeviceDetails.java
@@ -195,6 +195,7 @@ public class DeviceDetails implements Validatable {
         return secProductCaps;
     }
 
+    @Override
     public List<ValidationError> validate() {
         List<ValidationError> errors = new ArrayList<>();
 

--- a/bundles/org.jupnp/src/main/java/org/jupnp/model/meta/Icon.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/model/meta/Icon.java
@@ -158,6 +158,7 @@ public class Icon implements Validatable {
         this.device = device;
     }
 
+    @Override
     public List<ValidationError> validate() {
         List<ValidationError> errors = new ArrayList<>();
 

--- a/bundles/org.jupnp/src/main/java/org/jupnp/model/meta/StateVariable.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/model/meta/StateVariable.java
@@ -71,6 +71,7 @@ public class StateVariable<S extends Service> implements Validatable {
         this.service = service;
     }
 
+    @Override
     public List<ValidationError> validate() {
         List<ValidationError> errors = new ArrayList<>();
 

--- a/bundles/org.jupnp/src/main/java/org/jupnp/model/meta/StateVariableAllowedValueRange.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/model/meta/StateVariableAllowedValueRange.java
@@ -70,6 +70,7 @@ public class StateVariableAllowedValueRange implements Validatable {
         return value >= getMinimum() && value <= getMaximum() && (value % step) == 0;
     }
 
+    @Override
     public List<ValidationError> validate() {
         return new ArrayList<>();
     }

--- a/bundles/org.jupnp/src/main/java/org/jupnp/model/meta/StateVariableTypeDetails.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/model/meta/StateVariableTypeDetails.java
@@ -87,6 +87,7 @@ public class StateVariableTypeDetails implements Validatable {
         return false;
     }
 
+    @Override
     public List<ValidationError> validate() {
         List<ValidationError> errors = new ArrayList<>();
 

--- a/bundles/org.jupnp/src/main/java/org/jupnp/model/meta/UDAVersion.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/model/meta/UDAVersion.java
@@ -47,6 +47,7 @@ public class UDAVersion implements Validatable {
         return minor;
     }
 
+    @Override
     public List<ValidationError> validate() {
         List<ValidationError> errors = new ArrayList<>();
 

--- a/bundles/org.jupnp/src/main/java/org/jupnp/model/profile/HeaderDeviceDetailsProvider.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/model/profile/HeaderDeviceDetailsProvider.java
@@ -82,6 +82,7 @@ public class HeaderDeviceDetailsProvider implements DeviceDetailsProvider {
         return headerDetails;
     }
 
+    @Override
     public DeviceDetails provide(RemoteClientInfo info) {
         if (info == null || info.getRequestHeaders().isEmpty()) {
             return getDefaultDeviceDetails();

--- a/bundles/org.jupnp/src/main/java/org/jupnp/model/state/StateVariableAccessor.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/model/state/StateVariableAccessor.java
@@ -35,6 +35,7 @@ public abstract class StateVariableAccessor {
         class AccessCommand implements Command {
             Object result;
 
+            @Override
             public void execute(ServiceManager serviceManager) throws Exception {
                 result = read(serviceImpl);
                 if (stateVariable.getService().isStringConvertibleType(result)) {

--- a/bundles/org.jupnp/src/main/java/org/jupnp/model/types/AbstractDatatype.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/model/types/AbstractDatatype.java
@@ -38,6 +38,7 @@ public abstract class AbstractDatatype<V> implements Datatype<V> {
         return null;
     }
 
+    @Override
     public Builtin getBuiltin() {
         return builtin;
     }
@@ -46,6 +47,7 @@ public abstract class AbstractDatatype<V> implements Datatype<V> {
         this.builtin = builtin;
     }
 
+    @Override
     public String getString(V value) throws InvalidValueException {
         if (value == null) {
             return "";
@@ -56,6 +58,7 @@ public abstract class AbstractDatatype<V> implements Datatype<V> {
         return value.toString();
     }
 
+    @Override
     public boolean isValid(V value) {
         return value == null || getValueType().isAssignableFrom(value.getClass());
     }
@@ -65,6 +68,7 @@ public abstract class AbstractDatatype<V> implements Datatype<V> {
         return "(" + getClass().getSimpleName() + ")";
     }
 
+    @Override
     public String getDisplayString() {
         if (this instanceof CustomDatatype) {
             return ((CustomDatatype) this).getName();

--- a/bundles/org.jupnp/src/main/java/org/jupnp/model/types/Base64Datatype.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/model/types/Base64Datatype.java
@@ -25,10 +25,12 @@ public class Base64Datatype extends AbstractDatatype<byte[]> {
     public Base64Datatype() {
     }
 
+    @Override
     public Class<byte[]> getValueType() {
         return byte[].class;
     }
 
+    @Override
     public byte[] valueOf(String s) throws InvalidValueException {
         if (s.isEmpty()) {
             return null;

--- a/bundles/org.jupnp/src/main/java/org/jupnp/model/types/BinHexDatatype.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/model/types/BinHexDatatype.java
@@ -25,10 +25,12 @@ public class BinHexDatatype extends AbstractDatatype<byte[]> {
     public BinHexDatatype() {
     }
 
+    @Override
     public Class<byte[]> getValueType() {
         return byte[].class;
     }
 
+    @Override
     public byte[] valueOf(String s) throws InvalidValueException {
         if (s.isEmpty()) {
             return null;

--- a/bundles/org.jupnp/src/main/java/org/jupnp/model/types/BooleanDatatype.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/model/types/BooleanDatatype.java
@@ -30,6 +30,7 @@ public class BooleanDatatype extends AbstractDatatype<Boolean> {
         return type == Boolean.TYPE || Boolean.class.isAssignableFrom(type);
     }
 
+    @Override
     public Boolean valueOf(String s) throws InvalidValueException {
         if (s.isEmpty()) {
             return null;
@@ -45,6 +46,7 @@ public class BooleanDatatype extends AbstractDatatype<Boolean> {
         }
     }
 
+    @Override
     public String getString(Boolean value) throws InvalidValueException {
         if (value == null) {
             return "";

--- a/bundles/org.jupnp/src/main/java/org/jupnp/model/types/CharacterDatatype.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/model/types/CharacterDatatype.java
@@ -28,6 +28,7 @@ public class CharacterDatatype extends AbstractDatatype<Character> {
         return type == Character.TYPE || Character.class.isAssignableFrom(type);
     }
 
+    @Override
     public Character valueOf(String s) throws InvalidValueException {
         if (s.isEmpty()) {
             return null;

--- a/bundles/org.jupnp/src/main/java/org/jupnp/model/types/CustomDatatype.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/model/types/CustomDatatype.java
@@ -30,6 +30,7 @@ public class CustomDatatype extends AbstractDatatype<String> {
         return name;
     }
 
+    @Override
     public String valueOf(String s) throws InvalidValueException {
         if (s.isEmpty()) {
             return null;

--- a/bundles/org.jupnp/src/main/java/org/jupnp/model/types/DateTimeDatatype.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/model/types/DateTimeDatatype.java
@@ -34,6 +34,7 @@ public class DateTimeDatatype extends AbstractDatatype<Calendar> {
         this.writeFormat = writeFormat;
     }
 
+    @Override
     public Calendar valueOf(String s) throws InvalidValueException {
         if (s.isEmpty()) {
             return null;

--- a/bundles/org.jupnp/src/main/java/org/jupnp/model/types/DoubleDatatype.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/model/types/DoubleDatatype.java
@@ -28,6 +28,7 @@ public class DoubleDatatype extends AbstractDatatype<Double> {
         return type == Double.TYPE || Double.class.isAssignableFrom(type);
     }
 
+    @Override
     public Double valueOf(String s) throws InvalidValueException {
         if (s.isEmpty()) {
             return null;

--- a/bundles/org.jupnp/src/main/java/org/jupnp/model/types/FloatDatatype.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/model/types/FloatDatatype.java
@@ -28,6 +28,7 @@ public class FloatDatatype extends AbstractDatatype<Float> {
         return type == Float.TYPE || Float.class.isAssignableFrom(type);
     }
 
+    @Override
     public Float valueOf(String s) throws InvalidValueException {
         if (s.isEmpty()) {
             return null;

--- a/bundles/org.jupnp/src/main/java/org/jupnp/model/types/IntegerDatatype.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/model/types/IntegerDatatype.java
@@ -33,6 +33,7 @@ public class IntegerDatatype extends AbstractDatatype<Integer> {
         return type == Integer.TYPE || Integer.class.isAssignableFrom(type);
     }
 
+    @Override
     public Integer valueOf(String s) throws InvalidValueException {
         if (s.isEmpty()) {
             return null;
@@ -55,6 +56,7 @@ public class IntegerDatatype extends AbstractDatatype<Integer> {
         }
     }
 
+    @Override
     public boolean isValid(Integer value) {
         return value == null || (value >= getMinValue() && value <= getMaxValue());
     }

--- a/bundles/org.jupnp/src/main/java/org/jupnp/model/types/ShortDatatype.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/model/types/ShortDatatype.java
@@ -26,6 +26,7 @@ public class ShortDatatype extends AbstractDatatype<Short> {
         return type == Short.TYPE || Short.class.isAssignableFrom(type);
     }
 
+    @Override
     public Short valueOf(String s) throws InvalidValueException {
         if (s.isEmpty()) {
             return null;

--- a/bundles/org.jupnp/src/main/java/org/jupnp/model/types/StringDatatype.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/model/types/StringDatatype.java
@@ -23,6 +23,7 @@ public class StringDatatype extends AbstractDatatype<String> {
     public StringDatatype() {
     }
 
+    @Override
     public String valueOf(String s) throws InvalidValueException {
         if (s.isEmpty()) {
             return null;

--- a/bundles/org.jupnp/src/main/java/org/jupnp/model/types/URIDatatype.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/model/types/URIDatatype.java
@@ -26,6 +26,7 @@ public class URIDatatype extends AbstractDatatype<URI> {
     public URIDatatype() {
     }
 
+    @Override
     public URI valueOf(String s) throws InvalidValueException {
         if (s.isEmpty()) {
             return null;

--- a/bundles/org.jupnp/src/main/java/org/jupnp/model/types/UnsignedIntegerFourBytes.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/model/types/UnsignedIntegerFourBytes.java
@@ -28,6 +28,7 @@ public final class UnsignedIntegerFourBytes extends UnsignedVariableInteger {
         super(s);
     }
 
+    @Override
     public Bits getBits() {
         return Bits.THIRTYTWO;
     }

--- a/bundles/org.jupnp/src/main/java/org/jupnp/model/types/UnsignedIntegerFourBytesDatatype.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/model/types/UnsignedIntegerFourBytesDatatype.java
@@ -20,6 +20,7 @@ package org.jupnp.model.types;
  */
 public class UnsignedIntegerFourBytesDatatype extends AbstractDatatype<UnsignedIntegerFourBytes> {
 
+    @Override
     public UnsignedIntegerFourBytes valueOf(String s) throws InvalidValueException {
         if (s.isEmpty()) {
             return null;

--- a/bundles/org.jupnp/src/main/java/org/jupnp/model/types/UnsignedIntegerOneByte.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/model/types/UnsignedIntegerOneByte.java
@@ -28,6 +28,7 @@ public final class UnsignedIntegerOneByte extends UnsignedVariableInteger {
         super(s);
     }
 
+    @Override
     public Bits getBits() {
         return Bits.EIGHT;
     }

--- a/bundles/org.jupnp/src/main/java/org/jupnp/model/types/UnsignedIntegerOneByteDatatype.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/model/types/UnsignedIntegerOneByteDatatype.java
@@ -20,6 +20,7 @@ package org.jupnp.model.types;
  */
 public class UnsignedIntegerOneByteDatatype extends AbstractDatatype<UnsignedIntegerOneByte> {
 
+    @Override
     public UnsignedIntegerOneByte valueOf(String s) throws InvalidValueException {
         if (s.isEmpty()) {
             return null;

--- a/bundles/org.jupnp/src/main/java/org/jupnp/model/types/UnsignedIntegerTwoBytes.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/model/types/UnsignedIntegerTwoBytes.java
@@ -28,6 +28,7 @@ public final class UnsignedIntegerTwoBytes extends UnsignedVariableInteger {
         super(s);
     }
 
+    @Override
     public Bits getBits() {
         return Bits.SIXTEEN;
     }

--- a/bundles/org.jupnp/src/main/java/org/jupnp/model/types/UnsignedIntegerTwoBytesDatatype.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/model/types/UnsignedIntegerTwoBytesDatatype.java
@@ -20,6 +20,7 @@ package org.jupnp.model.types;
  */
 public class UnsignedIntegerTwoBytesDatatype extends AbstractDatatype<UnsignedIntegerTwoBytes> {
 
+    @Override
     public UnsignedIntegerTwoBytes valueOf(String s) throws InvalidValueException {
         if (s.isEmpty()) {
             return null;

--- a/bundles/org.jupnp/src/main/java/org/jupnp/protocol/ProtocolFactoryImpl.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/protocol/ProtocolFactoryImpl.java
@@ -76,10 +76,12 @@ public class ProtocolFactoryImpl implements ProtocolFactory {
         this.upnpService = upnpService;
     }
 
+    @Override
     public UpnpService getUpnpService() {
         return upnpService;
     }
 
+    @Override
     public ReceivingAsync createReceivingAsync(IncomingDatagramMessage message) throws ProtocolCreationException {
         log.trace("Creating protocol for incoming asynchronous: {}", message);
 
@@ -156,6 +158,7 @@ public class ProtocolFactoryImpl implements ProtocolFactory {
         return false;
     }
 
+    @Override
     public ReceivingSync createReceivingSync(StreamRequestMessage message) throws ProtocolCreationException {
         log.trace("Creating protocol for incoming synchronous: {}", message);
 
@@ -202,22 +205,27 @@ public class ProtocolFactoryImpl implements ProtocolFactory {
         throw new ProtocolCreationException("Protocol for message type not found: " + message);
     }
 
+    @Override
     public SendingNotificationAlive createSendingNotificationAlive(LocalDevice localDevice) {
         return new SendingNotificationAlive(getUpnpService(), localDevice);
     }
 
+    @Override
     public SendingNotificationByebye createSendingNotificationByebye(LocalDevice localDevice) {
         return new SendingNotificationByebye(getUpnpService(), localDevice);
     }
 
+    @Override
     public SendingSearch createSendingSearch(UpnpHeader searchTarget, int mxSeconds) {
         return new SendingSearch(getUpnpService(), searchTarget, mxSeconds);
     }
 
+    @Override
     public SendingAction createSendingAction(ActionInvocation actionInvocation, URL controlURL) {
         return new SendingAction(getUpnpService(), actionInvocation, controlURL);
     }
 
+    @Override
     public SendingSubscribe createSendingSubscribe(RemoteGENASubscription subscription)
             throws ProtocolCreationException {
         try {
@@ -230,14 +238,17 @@ public class ProtocolFactoryImpl implements ProtocolFactory {
         }
     }
 
+    @Override
     public SendingRenewal createSendingRenewal(RemoteGENASubscription subscription) {
         return new SendingRenewal(getUpnpService(), subscription);
     }
 
+    @Override
     public SendingUnsubscribe createSendingUnsubscribe(RemoteGENASubscription subscription) {
         return new SendingUnsubscribe(getUpnpService(), subscription);
     }
 
+    @Override
     public SendingEvent createSendingEvent(LocalGENASubscription subscription) {
         return new SendingEvent(getUpnpService(), subscription);
     }

--- a/bundles/org.jupnp/src/main/java/org/jupnp/protocol/ReceivingAsync.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/protocol/ReceivingAsync.java
@@ -56,6 +56,7 @@ public abstract class ReceivingAsync<M extends UpnpMessage> implements Runnable 
         return inputMessage;
     }
 
+    @Override
     public void run() {
         boolean proceed;
         try {

--- a/bundles/org.jupnp/src/main/java/org/jupnp/protocol/ReceivingSync.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/protocol/ReceivingSync.java
@@ -60,6 +60,7 @@ public abstract class ReceivingSync<IN extends StreamRequestMessage, OUT extends
         return outputMessage;
     }
 
+    @Override
     protected final void execute() throws RouterException {
         outputMessage = executeSync();
 

--- a/bundles/org.jupnp/src/main/java/org/jupnp/protocol/RetrieveRemoteDescriptors.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/protocol/RetrieveRemoteDescriptors.java
@@ -81,6 +81,7 @@ public class RetrieveRemoteDescriptors implements Runnable {
         return upnpService;
     }
 
+    @Override
     public void run() {
 
         URL deviceURL = rd.getIdentity().getDescriptorURL();

--- a/bundles/org.jupnp/src/main/java/org/jupnp/protocol/SendingAsync.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/protocol/SendingAsync.java
@@ -48,6 +48,7 @@ public abstract class SendingAsync implements Runnable {
         return upnpService;
     }
 
+    @Override
     public void run() {
         try {
             execute();

--- a/bundles/org.jupnp/src/main/java/org/jupnp/protocol/SendingSync.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/protocol/SendingSync.java
@@ -51,6 +51,7 @@ public abstract class SendingSync<IN extends StreamRequestMessage, OUT extends S
         return outputMessage;
     }
 
+    @Override
     protected final void execute() throws RouterException {
         outputMessage = executeSync();
     }

--- a/bundles/org.jupnp/src/main/java/org/jupnp/protocol/async/ReceivingNotification.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/protocol/async/ReceivingNotification.java
@@ -77,6 +77,7 @@ public class ReceivingNotification extends ReceivingAsync<IncomingNotificationRe
         super(upnpService, new IncomingNotificationRequest(inputMessage));
     }
 
+    @Override
     protected void execute() throws RouterException {
 
         UDN udn = getInputMessage().getUDN();

--- a/bundles/org.jupnp/src/main/java/org/jupnp/protocol/async/ReceivingSearch.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/protocol/async/ReceivingSearch.java
@@ -75,6 +75,7 @@ public class ReceivingSearch extends ReceivingAsync<IncomingSearchRequest> {
         super(upnpService, new IncomingSearchRequest(inputMessage));
     }
 
+    @Override
     protected void execute() throws RouterException {
         if (getUpnpService().getRouter() == null) {
             // TODO: http://mailinglists.945824.n3.nabble.com/rare-NPE-on-start-tp3078213p3142767.html

--- a/bundles/org.jupnp/src/main/java/org/jupnp/protocol/async/ReceivingSearchResponse.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/protocol/async/ReceivingSearchResponse.java
@@ -51,6 +51,7 @@ public class ReceivingSearchResponse extends ReceivingAsync<IncomingSearchRespon
         super(upnpService, new IncomingSearchResponse(inputMessage));
     }
 
+    @Override
     protected void execute() throws RouterException {
 
         if (!getInputMessage().isSearchResponseMessage()) {

--- a/bundles/org.jupnp/src/main/java/org/jupnp/protocol/async/SendingNotification.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/protocol/async/SendingNotification.java
@@ -58,6 +58,7 @@ public abstract class SendingNotification extends SendingAsync {
         return device;
     }
 
+    @Override
     protected void execute() throws RouterException {
 
         List<NetworkAddress> activeStreamServers = getUpnpService().getRouter().getActiveStreamServers(null);

--- a/bundles/org.jupnp/src/main/java/org/jupnp/protocol/async/SendingNotificationAlive.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/protocol/async/SendingNotificationAlive.java
@@ -41,6 +41,7 @@ public class SendingNotificationAlive extends SendingNotification {
         super.execute();
     }
 
+    @Override
     protected NotificationSubtype getNotificationSubtype() {
         return NotificationSubtype.ALIVE;
     }

--- a/bundles/org.jupnp/src/main/java/org/jupnp/protocol/async/SendingNotificationByebye.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/protocol/async/SendingNotificationByebye.java
@@ -50,6 +50,7 @@ public class SendingNotificationByebye extends SendingNotification {
         super.execute();
     }
 
+    @Override
     protected NotificationSubtype getNotificationSubtype() {
         return NotificationSubtype.BYEBYE;
     }

--- a/bundles/org.jupnp/src/main/java/org/jupnp/protocol/async/SendingSearch.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/protocol/async/SendingSearch.java
@@ -77,6 +77,7 @@ public class SendingSearch extends SendingAsync {
         return mxSeconds;
     }
 
+    @Override
     protected void execute() throws RouterException {
 
         log.trace("Executing search for target: {} with MX seconds: {}", searchTarget.getString(), getMxSeconds());

--- a/bundles/org.jupnp/src/main/java/org/jupnp/protocol/sync/ReceivingAction.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/protocol/sync/ReceivingAction.java
@@ -55,6 +55,7 @@ public class ReceivingAction extends ReceivingSync<StreamRequestMessage, StreamR
         super(upnpService, inputMessage);
     }
 
+    @Override
     protected StreamResponseMessage executeSync() throws RouterException {
 
         ContentTypeHeader contentTypeHeader = getInputMessage().getHeaders()

--- a/bundles/org.jupnp/src/main/java/org/jupnp/protocol/sync/ReceivingEvent.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/protocol/sync/ReceivingEvent.java
@@ -48,6 +48,7 @@ public class ReceivingEvent extends ReceivingSync<StreamRequestMessage, Outgoing
         super(upnpService, inputMessage);
     }
 
+    @Override
     protected OutgoingEventResponseMessage executeSync() throws RouterException {
 
         if (!getInputMessage().isContentTypeTextUDA()) {

--- a/bundles/org.jupnp/src/main/java/org/jupnp/protocol/sync/ReceivingRetrieval.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/protocol/sync/ReceivingRetrieval.java
@@ -60,6 +60,7 @@ public class ReceivingRetrieval extends ReceivingSync<StreamRequestMessage, Stre
         super(upnpService, inputMessage);
     }
 
+    @Override
     protected StreamResponseMessage executeSync() throws RouterException {
 
         if (!getInputMessage().hasHostHeader()) {

--- a/bundles/org.jupnp/src/main/java/org/jupnp/protocol/sync/ReceivingSubscribe.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/protocol/sync/ReceivingSubscribe.java
@@ -65,6 +65,7 @@ public class ReceivingSubscribe extends ReceivingSync<StreamRequestMessage, Outg
         super(upnpService, inputMessage);
     }
 
+    @Override
     protected OutgoingSubscribeResponseMessage executeSync() throws RouterException {
 
         ServiceEventSubscriptionResource resource = getUpnpService().getRegistry()
@@ -159,12 +160,15 @@ public class ReceivingSubscribe extends ReceivingSync<StreamRequestMessage, Outg
 
         try {
             subscription = new LocalGENASubscription(service, timeoutSeconds, callbackURLs) {
+                @Override
                 public void established() {
                 }
 
+                @Override
                 public void ended(CancelReason reason) {
                 }
 
+                @Override
                 public void eventReceived() {
                     // The only thing we are interested in, sending an event when the state changes
                     getUpnpService().getConfiguration().getSyncProtocolExecutorService()

--- a/bundles/org.jupnp/src/main/java/org/jupnp/protocol/sync/ReceivingUnsubscribe.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/protocol/sync/ReceivingUnsubscribe.java
@@ -40,6 +40,7 @@ public class ReceivingUnsubscribe extends ReceivingSync<StreamRequestMessage, St
         super(upnpService, inputMessage);
     }
 
+    @Override
     protected StreamResponseMessage executeSync() throws RouterException {
 
         ServiceEventSubscriptionResource resource = getUpnpService().getRegistry()

--- a/bundles/org.jupnp/src/main/java/org/jupnp/protocol/sync/SendingAction.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/protocol/sync/SendingAction.java
@@ -59,6 +59,7 @@ public class SendingAction extends SendingSync<OutgoingActionRequestMessage, Inc
         this.actionInvocation = actionInvocation;
     }
 
+    @Override
     protected IncomingActionResponseMessage executeSync() throws RouterException {
         return invokeRemote(getInputMessage());
     }

--- a/bundles/org.jupnp/src/main/java/org/jupnp/protocol/sync/SendingEvent.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/protocol/sync/SendingEvent.java
@@ -70,6 +70,7 @@ public class SendingEvent extends SendingSync<OutgoingEventRequestMessage, Strea
         subscription.incrementSequence();
     }
 
+    @Override
     protected StreamResponseMessage executeSync() throws RouterException {
 
         log.trace("Sending event for subscription: {}", subscriptionId);

--- a/bundles/org.jupnp/src/main/java/org/jupnp/protocol/sync/SendingRenewal.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/protocol/sync/SendingRenewal.java
@@ -51,6 +51,7 @@ public class SendingRenewal extends SendingSync<OutgoingRenewalRequestMessage, I
         this.subscription = subscription;
     }
 
+    @Override
     protected IncomingSubscribeResponseMessage executeSync() throws RouterException {
         log.trace("Sending subscription renewal request: {}", getInputMessage());
 

--- a/bundles/org.jupnp/src/main/java/org/jupnp/protocol/sync/SendingSubscribe.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/protocol/sync/SendingSubscribe.java
@@ -62,6 +62,7 @@ public class SendingSubscribe extends SendingSync<OutgoingSubscribeRequestMessag
         this.subscription = subscription;
     }
 
+    @Override
     protected IncomingSubscribeResponseMessage executeSync() throws RouterException {
 
         if (!getInputMessage().hasCallbackURLs()) {

--- a/bundles/org.jupnp/src/main/java/org/jupnp/protocol/sync/SendingUnsubscribe.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/protocol/sync/SendingUnsubscribe.java
@@ -49,6 +49,7 @@ public class SendingUnsubscribe extends SendingSync<OutgoingUnsubscribeRequestMe
         this.subscription = subscription;
     }
 
+    @Override
     protected StreamResponseMessage executeSync() throws RouterException {
 
         log.trace("Sending unsubscribe request: {}", getInputMessage());

--- a/bundles/org.jupnp/src/main/java/org/jupnp/registry/DefaultRegistryListener.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/registry/DefaultRegistryListener.java
@@ -31,9 +31,11 @@ import org.jupnp.model.meta.RemoteDevice;
  */
 public class DefaultRegistryListener implements RegistryListener {
 
+    @Override
     public void remoteDeviceDiscoveryStarted(Registry registry, RemoteDevice device) {
     }
 
+    @Override
     public void remoteDeviceDiscoveryFailed(Registry registry, RemoteDevice device, Exception ex) {
     }
 
@@ -43,10 +45,12 @@ public class DefaultRegistryListener implements RegistryListener {
      * @param registry The jUPnP registry of all devices and services know to the local UPnP stack.
      * @param device A validated and hydrated device metadata graph, with complete service metadata.
      */
+    @Override
     public void remoteDeviceAdded(Registry registry, RemoteDevice device) {
         deviceAdded(registry, device);
     }
 
+    @Override
     public void remoteDeviceUpdated(Registry registry, RemoteDevice device) {
     }
 
@@ -56,6 +60,7 @@ public class DefaultRegistryListener implements RegistryListener {
      * @param registry The jUPnP registry of all devices and services know to the local UPnP stack.
      * @param device A validated and hydrated device metadata graph, with complete service metadata.
      */
+    @Override
     public void remoteDeviceRemoved(Registry registry, RemoteDevice device) {
         deviceRemoved(registry, device);
     }
@@ -66,6 +71,7 @@ public class DefaultRegistryListener implements RegistryListener {
      * @param registry The jUPnP registry of all devices and services know to the local UPnP stack.
      * @param device The local device added to the {@link org.jupnp.registry.Registry}.
      */
+    @Override
     public void localDeviceAdded(Registry registry, LocalDevice device) {
         deviceAdded(registry, device);
     }
@@ -76,6 +82,7 @@ public class DefaultRegistryListener implements RegistryListener {
      * @param registry The jUPnP registry of all devices and services know to the local UPnP stack.
      * @param device The local device removed from the {@link org.jupnp.registry.Registry}.
      */
+    @Override
     public void localDeviceRemoved(Registry registry, LocalDevice device) {
         deviceRemoved(registry, device);
     }
@@ -86,9 +93,11 @@ public class DefaultRegistryListener implements RegistryListener {
     public void deviceRemoved(Registry registry, Device device) {
     }
 
+    @Override
     public void beforeShutdown(Registry registry) {
     }
 
+    @Override
     public void afterShutdown() {
     }
 }

--- a/bundles/org.jupnp/src/main/java/org/jupnp/registry/LocalItems.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/registry/LocalItems.java
@@ -72,6 +72,7 @@ class LocalItems extends RegistryItems<LocalDevice, LocalGENASubscription> {
         return getDiscoveryOptions(udn) != null && getDiscoveryOptions(udn).isByeByeBeforeFirstAlive();
     }
 
+    @Override
     void add(LocalDevice localDevice) throws RegistrationException {
         add(localDevice, null);
     }
@@ -126,6 +127,7 @@ class LocalItems extends RegistryItems<LocalDevice, LocalGENASubscription> {
         }
     }
 
+    @Override
     Collection<LocalDevice> get() {
         Set<LocalDevice> c = new HashSet<>();
         for (RegistryItem<UDN, LocalDevice> item : getDeviceItems()) {
@@ -134,6 +136,7 @@ class LocalItems extends RegistryItems<LocalDevice, LocalGENASubscription> {
         return Collections.unmodifiableCollection(c);
     }
 
+    @Override
     boolean remove(final LocalDevice localDevice) throws RegistrationException {
         return remove(localDevice, false);
     }
@@ -194,6 +197,7 @@ class LocalItems extends RegistryItems<LocalDevice, LocalGENASubscription> {
         return false;
     }
 
+    @Override
     void removeAll() {
         removeAll(false);
     }
@@ -217,6 +221,7 @@ class LocalItems extends RegistryItems<LocalDevice, LocalGENASubscription> {
 
     /* ############################################################################################################ */
 
+    @Override
     void maintain() {
 
         if (getDeviceItems().isEmpty()) {
@@ -272,6 +277,7 @@ class LocalItems extends RegistryItems<LocalDevice, LocalGENASubscription> {
         }
     }
 
+    @Override
     void shutdown() {
         log.trace("Clearing all registered subscriptions to local devices during shutdown");
         getSubscriptionItems().clear();

--- a/bundles/org.jupnp/src/main/java/org/jupnp/registry/RegistryImpl.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/registry/RegistryImpl.java
@@ -81,14 +81,17 @@ public class RegistryImpl implements Registry {
         }
     }
 
+    @Override
     public UpnpService getUpnpService() {
         return upnpService;
     }
 
+    @Override
     public UpnpServiceConfiguration getConfiguration() {
         return getUpnpService().getConfiguration();
     }
 
+    @Override
     public ProtocolFactory getProtocolFactory() {
         return getUpnpService().getProtocolFactory();
     }
@@ -112,18 +115,22 @@ public class RegistryImpl implements Registry {
 
     // #################################################################################################
 
+    @Override
     public void addListener(RegistryListener listener) {
         registryListeners.add(listener);
     }
 
+    @Override
     public void removeListener(RegistryListener listener) {
         registryListeners.remove(listener);
     }
 
+    @Override
     public Collection<RegistryListener> getListeners() {
         return Collections.unmodifiableCollection(registryListeners);
     }
 
+    @Override
     public boolean notifyDiscoveryStart(final RemoteDevice device) {
         // Exit if we have it already, this is atomic inside this method, finally
         if (getRemoteDevice(device.getIdentity().getUdn(), true) != null) {
@@ -142,6 +149,7 @@ public class RegistryImpl implements Registry {
         return true;
     }
 
+    @Override
     public void notifyDiscoveryFailure(final RemoteDevice device, final Exception ex) {
         for (final RegistryListener listener : getListeners()) {
             getConfiguration().getRegistryListenerExecutor().execute(new Runnable() {
@@ -154,6 +162,7 @@ public class RegistryImpl implements Registry {
 
     // #################################################################################################
 
+    @Override
     public void addDevice(LocalDevice localDevice) {
         remoteItemsLock.readLock().lock();
         try {
@@ -168,6 +177,7 @@ public class RegistryImpl implements Registry {
         }
     }
 
+    @Override
     public void addDevice(LocalDevice localDevice, DiscoveryOptions options) {
         remoteItemsLock.readLock().lock();
         try {
@@ -182,6 +192,7 @@ public class RegistryImpl implements Registry {
         }
     }
 
+    @Override
     public void setDiscoveryOptions(UDN udn, DiscoveryOptions options) {
         localItemsLock.writeLock().lock();
         try {
@@ -191,6 +202,7 @@ public class RegistryImpl implements Registry {
         }
     }
 
+    @Override
     public DiscoveryOptions getDiscoveryOptions(UDN udn) {
         localItemsLock.readLock().lock();
         try {
@@ -200,6 +212,7 @@ public class RegistryImpl implements Registry {
         }
     }
 
+    @Override
     public void addDevice(RemoteDevice remoteDevice) {
         remoteItemsLock.writeLock().lock();
         try {
@@ -214,6 +227,7 @@ public class RegistryImpl implements Registry {
         }
     }
 
+    @Override
     public boolean update(RemoteDeviceIdentity rdIdentity) {
         remoteItemsLock.writeLock().lock();
         try {
@@ -228,6 +242,7 @@ public class RegistryImpl implements Registry {
         }
     }
 
+    @Override
     public boolean removeDevice(LocalDevice localDevice) {
         localItemsLock.writeLock().lock();
         try {
@@ -237,6 +252,7 @@ public class RegistryImpl implements Registry {
         }
     }
 
+    @Override
     public boolean removeDevice(RemoteDevice remoteDevice) {
         remoteItemsLock.writeLock().lock();
         try {
@@ -246,6 +262,7 @@ public class RegistryImpl implements Registry {
         }
     }
 
+    @Override
     public void removeAllLocalDevices() {
         localItemsLock.writeLock().lock();
         try {
@@ -255,6 +272,7 @@ public class RegistryImpl implements Registry {
         }
     }
 
+    @Override
     public void removeAllRemoteDevices() {
         remoteItemsLock.writeLock().lock();
         try {
@@ -264,6 +282,7 @@ public class RegistryImpl implements Registry {
         }
     }
 
+    @Override
     public boolean removeDevice(UDN udn) {
         Device device = getDevice(udn, true);
         if (device != null && device instanceof LocalDevice) {
@@ -275,6 +294,7 @@ public class RegistryImpl implements Registry {
         return false;
     }
 
+    @Override
     public Device getDevice(UDN udn, boolean rootOnly) {
         Device device;
 
@@ -288,6 +308,7 @@ public class RegistryImpl implements Registry {
         return null;
     }
 
+    @Override
     public LocalDevice getLocalDevice(UDN udn, boolean rootOnly) {
         localItemsLock.readLock().lock();
         try {
@@ -297,6 +318,7 @@ public class RegistryImpl implements Registry {
         }
     }
 
+    @Override
     public RemoteDevice getRemoteDevice(UDN udn, boolean rootOnly) {
         remoteItemsLock.readLock().lock();
         try {
@@ -306,6 +328,7 @@ public class RegistryImpl implements Registry {
         }
     }
 
+    @Override
     public Collection<LocalDevice> getLocalDevices() {
         localItemsLock.readLock().lock();
         try {
@@ -315,6 +338,7 @@ public class RegistryImpl implements Registry {
         }
     }
 
+    @Override
     public Collection<RemoteDevice> getRemoteDevices() {
         remoteItemsLock.readLock().lock();
         try {
@@ -324,6 +348,7 @@ public class RegistryImpl implements Registry {
         }
     }
 
+    @Override
     public Collection<Device> getDevices() {
         Set<Device> all = new HashSet<>();
 
@@ -344,6 +369,7 @@ public class RegistryImpl implements Registry {
         return Collections.unmodifiableCollection(all);
     }
 
+    @Override
     public Collection<Device> getDevices(DeviceType deviceType) {
         Collection<Device> devices = new HashSet<>();
 
@@ -364,6 +390,7 @@ public class RegistryImpl implements Registry {
         return Collections.unmodifiableCollection(devices);
     }
 
+    @Override
     public Collection<Device> getDevices(ServiceType serviceType) {
         Collection<Device> devices = new HashSet<>();
 
@@ -384,6 +411,7 @@ public class RegistryImpl implements Registry {
         return Collections.unmodifiableCollection(devices);
     }
 
+    @Override
     public Service getService(ServiceReference serviceReference) {
         Device device;
         if ((device = getDevice(serviceReference.getUdn(), false)) != null) {
@@ -394,6 +422,7 @@ public class RegistryImpl implements Registry {
 
     // #################################################################################################
 
+    @Override
     public Resource getResource(URI pathQuery) throws IllegalArgumentException {
         if (pathQuery.isAbsolute()) {
             throw new IllegalArgumentException("Resource URI can not be absolute, only path and query:" + pathQuery);
@@ -426,6 +455,7 @@ public class RegistryImpl implements Registry {
         return null;
     }
 
+    @Override
     public <T extends Resource> T getResource(Class<T> resourceType, URI pathQuery) throws IllegalArgumentException {
         Resource resource = getResource(pathQuery);
         if (resource != null && resourceType.isAssignableFrom(resource.getClass())) {
@@ -434,6 +464,7 @@ public class RegistryImpl implements Registry {
         return null;
     }
 
+    @Override
     public Collection<Resource> getResources() {
         Collection<Resource> s = new HashSet<>(resourceItems.size());
 
@@ -443,6 +474,7 @@ public class RegistryImpl implements Registry {
         return s;
     }
 
+    @Override
     public <T extends Resource> Collection<T> getResources(Class<T> resourceType) {
         Collection<T> s = new HashSet<>(resourceItems.size());
         for (RegistryItem<URI, Resource> resourceItem : resourceItems) {
@@ -453,10 +485,12 @@ public class RegistryImpl implements Registry {
         return s;
     }
 
+    @Override
     public void addResource(Resource resource) {
         addResource(resource, ExpirationDetails.UNLIMITED_AGE);
     }
 
+    @Override
     public void addResource(Resource resource, int maxAgeSeconds) {
         RegistryItem resourceItem = new RegistryItem(resource.getPathQuery(), resource, maxAgeSeconds);
 
@@ -464,12 +498,14 @@ public class RegistryImpl implements Registry {
         resourceItems.add(resourceItem);
     }
 
+    @Override
     public boolean removeResource(Resource resource) {
         return resourceItems.remove(new RegistryItem<>(resource.getPathQuery()));
     }
 
     // #################################################################################################
 
+    @Override
     public void addLocalSubscription(LocalGENASubscription subscription) {
         localItemsLock.writeLock().lock();
         try {
@@ -479,6 +515,7 @@ public class RegistryImpl implements Registry {
         }
     }
 
+    @Override
     public LocalGENASubscription getLocalSubscription(String subscriptionId) {
         localItemsLock.readLock().lock();
         try {
@@ -488,6 +525,7 @@ public class RegistryImpl implements Registry {
         }
     }
 
+    @Override
     public boolean updateLocalSubscription(LocalGENASubscription subscription) {
         localItemsLock.writeLock().lock();
         try {
@@ -497,6 +535,7 @@ public class RegistryImpl implements Registry {
         }
     }
 
+    @Override
     public boolean removeLocalSubscription(LocalGENASubscription subscription) {
         localItemsLock.writeLock().lock();
         try {
@@ -506,6 +545,7 @@ public class RegistryImpl implements Registry {
         }
     }
 
+    @Override
     public void addRemoteSubscription(RemoteGENASubscription subscription) {
         remoteItemsLock.writeLock().lock();
         try {
@@ -515,6 +555,7 @@ public class RegistryImpl implements Registry {
         }
     }
 
+    @Override
     public RemoteGENASubscription getRemoteSubscription(String subscriptionId) {
         remoteItemsLock.readLock().lock();
         try {
@@ -524,6 +565,7 @@ public class RegistryImpl implements Registry {
         }
     }
 
+    @Override
     public void updateRemoteSubscription(RemoteGENASubscription subscription) {
         remoteItemsLock.writeLock().lock();
         try {
@@ -533,6 +575,7 @@ public class RegistryImpl implements Registry {
         }
     }
 
+    @Override
     public void removeRemoteSubscription(RemoteGENASubscription subscription) {
         remoteItemsLock.writeLock().lock();
         try {
@@ -544,6 +587,7 @@ public class RegistryImpl implements Registry {
 
     /* ############################################################################################################ */
 
+    @Override
     public void advertiseLocalDevices() {
         localItemsLock.readLock().lock();
         try {
@@ -556,6 +600,7 @@ public class RegistryImpl implements Registry {
     /* ############################################################################################################ */
 
     // When you call this, make sure you have the Router lock before this lock is obtained!
+    @Override
     public void shutdown() {
         log.trace("Shutting down registry...");
 
@@ -599,6 +644,7 @@ public class RegistryImpl implements Registry {
         }
     }
 
+    @Override
     public void pause() {
         synchronized (lock) {
             if (registryMaintainer != null) {
@@ -610,6 +656,7 @@ public class RegistryImpl implements Registry {
         }
     }
 
+    @Override
     public void resume() {
         synchronized (lock) {
             if (registryMaintainer == null) {
@@ -634,6 +681,7 @@ public class RegistryImpl implements Registry {
         }
     }
 
+    @Override
     public boolean isPaused() {
         synchronized (lock) {
             return registryMaintainer == null;

--- a/bundles/org.jupnp/src/main/java/org/jupnp/registry/RegistryMaintainer.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/registry/RegistryMaintainer.java
@@ -42,6 +42,7 @@ public class RegistryMaintainer implements Runnable {
         stopped = true;
     }
 
+    @Override
     public void run() {
         stopped = false;
         log.trace("Running registry maintenance loop every milliseconds: {}", sleepIntervalMillis);

--- a/bundles/org.jupnp/src/main/java/org/jupnp/registry/RemoteItems.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/registry/RemoteItems.java
@@ -60,6 +60,7 @@ class RemoteItems extends RegistryItems<RemoteDevice, RemoteGENASubscription> {
      *
      * @param device The remote device to be added
      */
+    @Override
     void add(final RemoteDevice device) {
 
         if (update(device.getIdentity())) {
@@ -181,6 +182,7 @@ class RemoteItems extends RegistryItems<RemoteDevice, RemoteGENASubscription> {
      * @param remoteDevice The device to remove from the registry.
      * @return <tt>true</tt> if the given device was found and removed from the registry, false if it wasn't registered.
      */
+    @Override
     boolean remove(final RemoteDevice remoteDevice) {
         return remove(remoteDevice, false);
     }
@@ -238,6 +240,7 @@ class RemoteItems extends RegistryItems<RemoteDevice, RemoteGENASubscription> {
         return false;
     }
 
+    @Override
     void removeAll() {
         removeAll(false);
     }
@@ -255,6 +258,7 @@ class RemoteItems extends RegistryItems<RemoteDevice, RemoteGENASubscription> {
         // Noop
     }
 
+    @Override
     void maintain() {
 
         if (getDeviceItems().isEmpty()) {
@@ -301,6 +305,7 @@ class RemoteItems extends RegistryItems<RemoteDevice, RemoteGENASubscription> {
         }
     }
 
+    @Override
     void shutdown() {
         log.trace("Cancelling all outgoing subscriptions to remote devices during shutdown");
         List<RemoteGENASubscription> remoteSubscriptions = new ArrayList<>();

--- a/bundles/org.jupnp/src/main/java/org/jupnp/transport/RouterImpl.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/transport/RouterImpl.java
@@ -97,10 +97,12 @@ public class RouterImpl implements Router {
         return disable();
     }
 
+    @Override
     public UpnpServiceConfiguration getConfiguration() {
         return configuration;
     }
 
+    @Override
     public ProtocolFactory getProtocolFactory() {
         return protocolFactory;
     }
@@ -205,6 +207,7 @@ public class RouterImpl implements Router {
         }
     }
 
+    @Override
     public List<NetworkAddress> getActiveStreamServers(InetAddress preferredAddress) throws RouterException {
         lock(readLock);
         try {
@@ -246,6 +249,7 @@ public class RouterImpl implements Router {
      *
      * @param msg The received datagram message.
      */
+    @Override
     public void received(IncomingDatagramMessage msg) {
         if (!enabled) {
             log.debug("Router disabled, ignoring incoming message: {}", msg);
@@ -270,6 +274,7 @@ public class RouterImpl implements Router {
      *
      * @param stream The received {@link org.jupnp.transport.spi.UpnpStream}.
      */
+    @Override
     public void received(UpnpStream stream) {
         if (!enabled) {
             log.debug("Router disabled, ignoring incoming: {}", stream);
@@ -284,6 +289,7 @@ public class RouterImpl implements Router {
      *
      * @param msg The UDP datagram message to send.
      */
+    @Override
     public void send(OutgoingDatagramMessage msg) throws RouterException {
         lock(readLock);
         try {
@@ -306,6 +312,7 @@ public class RouterImpl implements Router {
      * @return The return value of the {@link org.jupnp.transport.spi.StreamClient#sendRequest(StreamRequestMessage)}
      *         method or <code>null</code> if no <code>StreamClient</code> is available.
      */
+    @Override
     public StreamResponseMessage send(StreamRequestMessage msg) throws RouterException {
         lock(readLock);
         try {
@@ -338,6 +345,7 @@ public class RouterImpl implements Router {
      *
      * @param bytes The byte payload of the UDP datagram.
      */
+    @Override
     public void broadcast(byte[] bytes) throws RouterException {
         lock(readLock);
         try {

--- a/bundles/org.jupnp/src/main/java/org/jupnp/transport/impl/DatagramIOConfigurationImpl.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/transport/impl/DatagramIOConfigurationImpl.java
@@ -38,6 +38,7 @@ public class DatagramIOConfigurationImpl implements DatagramIOConfiguration {
         this.maxDatagramBytes = maxDatagramBytes;
     }
 
+    @Override
     public int getTimeToLive() {
         return timeToLive;
     }
@@ -46,6 +47,7 @@ public class DatagramIOConfigurationImpl implements DatagramIOConfiguration {
         this.timeToLive = timeToLive;
     }
 
+    @Override
     public int getMaxDatagramBytes() {
         return maxDatagramBytes;
     }

--- a/bundles/org.jupnp/src/main/java/org/jupnp/transport/impl/DatagramIOImpl.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/transport/impl/DatagramIOImpl.java
@@ -71,10 +71,12 @@ public class DatagramIOImpl implements DatagramIO<DatagramIOConfigurationImpl> {
         this.configuration = configuration;
     }
 
+    @Override
     public DatagramIOConfigurationImpl getConfiguration() {
         return configuration;
     }
 
+    @Override
     public synchronized void init(InetAddress bindAddress, int bindPort, Router router,
             DatagramProcessor datagramProcessor) throws InitializationException {
 
@@ -96,12 +98,14 @@ public class DatagramIOImpl implements DatagramIO<DatagramIOConfigurationImpl> {
         }
     }
 
+    @Override
     public synchronized void stop() {
         if (socket != null && !socket.isClosed()) {
             socket.close();
         }
     }
 
+    @Override
     public void run() {
         log.debug("Entering blocking receiving loop, listening for UDP datagrams on: {}:{}", socket.getLocalAddress(),
                 socket.getPort());
@@ -138,6 +142,7 @@ public class DatagramIOImpl implements DatagramIO<DatagramIOConfigurationImpl> {
         }
     }
 
+    @Override
     public synchronized void send(OutgoingDatagramMessage message) {
         log.debug("Sending message from address: {}", localAddress);
 
@@ -149,6 +154,7 @@ public class DatagramIOImpl implements DatagramIO<DatagramIOConfigurationImpl> {
         send(packet);
     }
 
+    @Override
     public synchronized void send(DatagramPacket datagram) {
         log.debug("Sending message from address: {}", localAddress);
 

--- a/bundles/org.jupnp/src/main/java/org/jupnp/transport/impl/DatagramProcessorImpl.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/transport/impl/DatagramProcessorImpl.java
@@ -42,6 +42,7 @@ public class DatagramProcessorImpl implements DatagramProcessor {
 
     private Logger log = LoggerFactory.getLogger(DatagramProcessor.class);
 
+    @Override
     public IncomingDatagramMessage read(InetAddress receivedOnAddress, DatagramPacket datagram)
             throws UnsupportedDataException {
 
@@ -70,6 +71,7 @@ public class DatagramProcessorImpl implements DatagramProcessor {
         }
     }
 
+    @Override
     public DatagramPacket write(OutgoingDatagramMessage message) throws UnsupportedDataException {
 
         StringBuilder statusLine = new StringBuilder();

--- a/bundles/org.jupnp/src/main/java/org/jupnp/transport/impl/GENAEventProcessorImpl.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/transport/impl/GENAEventProcessorImpl.java
@@ -54,6 +54,7 @@ public class GENAEventProcessorImpl extends PooledXmlProcessor implements GENAEv
         return DocumentBuilderFactory.newInstance();
     }
 
+    @Override
     public void writeBody(OutgoingEventRequestMessage requestMessage) throws UnsupportedDataException {
         log.trace("Writing body of: {}", requestMessage);
 
@@ -79,6 +80,7 @@ public class GENAEventProcessorImpl extends PooledXmlProcessor implements GENAEv
         }
     }
 
+    @Override
     public void readBody(IncomingEventRequestMessage requestMessage) throws UnsupportedDataException {
 
         log.trace("Reading body of: {}", requestMessage);
@@ -198,14 +200,17 @@ public class GENAEventProcessorImpl extends PooledXmlProcessor implements GENAEv
                 : node.getNodeName();
     }
 
+    @Override
     public void warning(SAXParseException e) throws SAXException {
         log.warn(e.toString());
     }
 
+    @Override
     public void error(SAXParseException e) throws SAXException {
         throw e;
     }
 
+    @Override
     public void fatalError(SAXParseException e) throws SAXException {
         throw e;
     }

--- a/bundles/org.jupnp/src/main/java/org/jupnp/transport/impl/MulticastReceiverConfigurationImpl.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/transport/impl/MulticastReceiverConfigurationImpl.java
@@ -56,6 +56,7 @@ public class MulticastReceiverConfigurationImpl implements MulticastReceiverConf
         this(InetAddress.getByName(group), port, 640);
     }
 
+    @Override
     public InetAddress getGroup() {
         return group;
     }
@@ -64,6 +65,7 @@ public class MulticastReceiverConfigurationImpl implements MulticastReceiverConf
         this.group = group;
     }
 
+    @Override
     public int getPort() {
         return port;
     }
@@ -72,6 +74,7 @@ public class MulticastReceiverConfigurationImpl implements MulticastReceiverConf
         this.port = port;
     }
 
+    @Override
     public int getMaxDatagramBytes() {
         return maxDatagramBytes;
     }

--- a/bundles/org.jupnp/src/main/java/org/jupnp/transport/impl/MulticastReceiverImpl.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/transport/impl/MulticastReceiverImpl.java
@@ -59,10 +59,12 @@ public class MulticastReceiverImpl implements MulticastReceiver<MulticastReceive
         this.configuration = configuration;
     }
 
+    @Override
     public MulticastReceiverConfigurationImpl getConfiguration() {
         return configuration;
     }
 
+    @Override
     public synchronized void init(NetworkInterface networkInterface, Router router,
             NetworkAddressFactory networkAddressFactory, DatagramProcessor datagramProcessor)
             throws InitializationException {
@@ -91,6 +93,7 @@ public class MulticastReceiverImpl implements MulticastReceiver<MulticastReceive
         }
     }
 
+    @Override
     public synchronized void stop() {
         if (socket != null && !socket.isClosed()) {
             try {
@@ -106,6 +109,7 @@ public class MulticastReceiverImpl implements MulticastReceiver<MulticastReceive
         }
     }
 
+    @Override
     public void run() {
 
         log.debug("Entering blocking receiving loop, listening for UDP datagrams on: {}", socket.getLocalAddress());

--- a/bundles/org.jupnp/src/main/java/org/jupnp/transport/impl/SOAPActionProcessorImpl.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/transport/impl/SOAPActionProcessorImpl.java
@@ -57,6 +57,7 @@ public class SOAPActionProcessorImpl extends PooledXmlProcessor implements SOAPA
     public SOAPActionProcessorImpl() {
     }
 
+    @Override
     public void writeBody(ActionRequestMessage requestMessage, ActionInvocation actionInvocation)
             throws UnsupportedDataException {
 
@@ -81,6 +82,7 @@ public class SOAPActionProcessorImpl extends PooledXmlProcessor implements SOAPA
         }
     }
 
+    @Override
     public void writeBody(ActionResponseMessage responseMessage, ActionInvocation actionInvocation)
             throws UnsupportedDataException {
 
@@ -109,6 +111,7 @@ public class SOAPActionProcessorImpl extends PooledXmlProcessor implements SOAPA
         }
     }
 
+    @Override
     public void readBody(ActionRequestMessage requestMessage, ActionInvocation actionInvocation)
             throws UnsupportedDataException {
 
@@ -132,6 +135,7 @@ public class SOAPActionProcessorImpl extends PooledXmlProcessor implements SOAPA
         }
     }
 
+    @Override
     public void readBody(ActionResponseMessage responseMsg, ActionInvocation actionInvocation)
             throws UnsupportedDataException {
 
@@ -579,14 +583,17 @@ public class SOAPActionProcessorImpl extends PooledXmlProcessor implements SOAPA
         return null;
     }
 
+    @Override
     public void warning(SAXParseException e) throws SAXException {
         log.warn(e.toString());
     }
 
+    @Override
     public void error(SAXParseException e) throws SAXException {
         throw e;
     }
 
+    @Override
     public void fatalError(SAXParseException e) throws SAXException {
         throw e;
     }

--- a/bundles/org.jupnp/src/main/java/org/jupnp/transport/impl/ServletStreamServerConfigurationImpl.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/transport/impl/ServletStreamServerConfigurationImpl.java
@@ -55,6 +55,7 @@ public class ServletStreamServerConfigurationImpl implements StreamServerConfigu
     /**
      * @return Defaults to <code>0</code>.
      */
+    @Override
     public int getListenPort() {
         return listenPort;
     }

--- a/bundles/org.jupnp/src/main/java/org/jupnp/transport/spi/AbstractStreamClientConfiguration.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/transport/spi/AbstractStreamClientConfiguration.java
@@ -56,6 +56,7 @@ public abstract class AbstractStreamClientConfiguration implements StreamClientC
         this.retryIterations = retryIterations;
     }
 
+    @Override
     public ExecutorService getRequestExecutorService() {
         return requestExecutorService;
     }
@@ -63,6 +64,7 @@ public abstract class AbstractStreamClientConfiguration implements StreamClientC
     /**
      * @return Configured value or default of 60 seconds.
      */
+    @Override
     public int getTimeoutSeconds() {
         return timeoutSeconds;
     }
@@ -70,6 +72,7 @@ public abstract class AbstractStreamClientConfiguration implements StreamClientC
     /**
      * @return Configured value or default of 5 retries.
      */
+    @Override
     public int getRetryIterations() {
         return retryIterations;
     }
@@ -77,10 +80,12 @@ public abstract class AbstractStreamClientConfiguration implements StreamClientC
     /**
      * @return Configured value or default of 5 seconds.
      */
+    @Override
     public int getLogWarningSeconds() {
         return logWarningSeconds;
     }
 
+    @Override
     public int getRetryAfterSeconds() {
         return retryAfterSeconds;
     }
@@ -88,6 +93,7 @@ public abstract class AbstractStreamClientConfiguration implements StreamClientC
     /**
      * @return Defaults to string value of {@link org.jupnp.model.ServerClientTokens}.
      */
+    @Override
     public String getUserAgentValue(int majorVersion, int minorVersion) {
         return new ServerClientTokens(majorVersion, minorVersion).toString();
     }

--- a/bundles/org.jupnp/src/main/java/org/jupnp/util/Iterators.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/util/Iterators.java
@@ -30,14 +30,17 @@ public class Iterators {
      */
     public static class Empty<E> implements Iterator<E> {
 
+        @Override
         public boolean hasNext() {
             return false;
         }
 
+        @Override
         public E next() {
             throw new NoSuchElementException();
         }
 
+        @Override
         public void remove() {
             throw new UnsupportedOperationException();
         }
@@ -55,15 +58,18 @@ public class Iterators {
             this.element = element;
         }
 
+        @Override
         public boolean hasNext() {
             return current == 0;
         }
 
+        @Override
         public E next() {
             current++;
             return element;
         }
 
+        @Override
         public void remove() {
             throw new UnsupportedOperationException();
         }
@@ -87,16 +93,19 @@ public class Iterators {
             this.wrapped = new CopyOnWriteArrayList<>(collection).iterator();
         }
 
+        @Override
         public boolean hasNext() {
             return wrapped.hasNext();
         }
 
+        @Override
         public E next() {
             removedCurrent = false;
             nextIndex++;
             return wrapped.next();
         }
 
+        @Override
         public void remove() {
             if (nextIndex == 0) {
                 throw new IllegalStateException("Call next() first");

--- a/bundles/org.jupnp/src/main/java/org/jupnp/util/statemachine/StateMachineInvocationHandler.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/util/statemachine/StateMachineInvocationHandler.java
@@ -73,6 +73,7 @@ public class StateMachineInvocationHandler implements InvocationHandler {
         }
     }
 
+    @Override
     public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
         synchronized (this) {
 

--- a/bundles/org.jupnp/src/main/java/org/jupnp/xml/CatalogResourceResolver.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/xml/CatalogResourceResolver.java
@@ -47,6 +47,7 @@ public class CatalogResourceResolver implements LSResourceResolver {
         this.catalog = catalog;
     }
 
+    @Override
     public LSInput resolveResource(String type, String namespaceURI, String publicId, String systemId, String baseURI) {
         log.trace("Trying to resolve system identifier URI in catalog: {}", systemId);
         URL systemURL;
@@ -77,59 +78,75 @@ public class CatalogResourceResolver implements LSResourceResolver {
             this.in = in;
         }
 
+        @Override
         public Reader getCharacterStream() {
             return null;
         }
 
+        @Override
         public void setCharacterStream(Reader characterStream) {
         }
 
+        @Override
         public InputStream getByteStream() {
             return in;
         }
 
+        @Override
         public void setByteStream(InputStream byteStream) {
         }
 
+        @Override
         public String getStringData() {
             return null;
         }
 
+        @Override
         public void setStringData(String stringData) {
         }
 
+        @Override
         public String getSystemId() {
             return null;
         }
 
+        @Override
         public void setSystemId(String systemId) {
         }
 
+        @Override
         public String getPublicId() {
             return null;
         }
 
+        @Override
         public void setPublicId(String publicId) {
         }
 
+        @Override
         public String getBaseURI() {
             return null;
         }
 
+        @Override
         public void setBaseURI(String baseURI) {
         }
 
+        @Override
         public String getEncoding() {
             return null;
         }
 
+        @Override
         public void setEncoding(String encoding) {
         }
 
+        @Override
         public boolean getCertifiedText() {
             return false;
         }
 
+        @Override
         public void setCertifiedText(boolean certifiedText) {
         }
     }

--- a/bundles/org.jupnp/src/main/java/org/jupnp/xml/DOMParser.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/xml/DOMParser.java
@@ -465,14 +465,17 @@ public abstract class DOMParser<D extends DOM> implements ErrorHandler, EntityRe
 
     // =================================================================================================
 
+    @Override
     public void warning(SAXParseException e) throws SAXException {
         log.warn(e.toString());
     }
 
+    @Override
     public void error(SAXParseException e) throws SAXException {
         throw new SAXException(new ParserException(e));
     }
 
+    @Override
     public void fatalError(SAXParseException e) throws SAXException {
         throw new SAXException(new ParserException(e));
     }
@@ -487,6 +490,7 @@ public abstract class DOMParser<D extends DOM> implements ErrorHandler, EntityRe
 
     // =================================================================================================
 
+    @Override
     public InputSource resolveEntity(String publicId, String systemId) throws SAXException, IOException {
         // By default this builds an EntityResolver that _stays offline_.
         // Damn you XML clowns, just because a URI looks like a URL does NOT mean you should fetch it!

--- a/bundles/org.jupnp/src/main/java/org/jupnp/xml/NamespaceContextMap.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/xml/NamespaceContextMap.java
@@ -32,6 +32,7 @@ import javax.xml.namespace.NamespaceContext;
  */
 public abstract class NamespaceContextMap extends HashMap<String, String> implements NamespaceContext {
 
+    @Override
     public String getNamespaceURI(String prefix) {
         if (prefix == null) {
             throw new IllegalArgumentException("No prefix provided!");
@@ -45,11 +46,13 @@ public abstract class NamespaceContextMap extends HashMap<String, String> implem
     }
 
     // Whatever, we don't care
+    @Override
     public String getPrefix(String namespaceURI) {
         return null;
     }
 
     // Whatever, we don't care
+    @Override
     public Iterator getPrefixes(String s) {
         return null;
     }

--- a/bundles/org.jupnp/src/main/java/org/jupnp/xml/SAXParser.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/xml/SAXParser.java
@@ -117,14 +117,17 @@ public class SAXParser {
      * Always throws exceptions and stops parsing.
      */
     public static class SimpleErrorHandler implements ErrorHandler {
+        @Override
         public void warning(SAXParseException e) throws SAXException {
             throw new SAXException(e);
         }
 
+        @Override
         public void error(SAXParseException e) throws SAXException {
             throw new SAXException(e);
         }
 
+        @Override
         public void fatalError(SAXParseException e) throws SAXException {
             throw new SAXException(e);
         }

--- a/bundles/org.jupnp/src/test/java/example/binarylight/BinaryLightClient.java
+++ b/bundles/org.jupnp/src/test/java/example/binarylight/BinaryLightClient.java
@@ -34,6 +34,7 @@ public class BinaryLightClient implements Runnable {
         clientThread.start();
     }
 
+    @Override
     public void run() {
         try {
             UpnpService upnpService = new UpnpServiceImpl();

--- a/bundles/org.jupnp/src/test/java/example/binarylight/BinaryLightServer.java
+++ b/bundles/org.jupnp/src/test/java/example/binarylight/BinaryLightServer.java
@@ -34,6 +34,7 @@ public class BinaryLightServer implements Runnable {
         serverThread.start();
     }
 
+    @Override
     public void run() {
         try {
 

--- a/bundles/org.jupnp/src/test/java/example/localservice/EventProviderTest.java
+++ b/bundles/org.jupnp/src/test/java/example/localservice/EventProviderTest.java
@@ -121,6 +121,7 @@ class EventProviderTest extends EventSubscriptionTest {
                 testAssertions.add(true);
             }
 
+            @Override
             public void eventReceived(GENASubscription subscription) {
                 if (subscription.getCurrentSequence().getValue() == 0) {
                     assertEquals("0", subscription.getCurrentValues().get("Status").toString());
@@ -133,6 +134,7 @@ class EventProviderTest extends EventSubscriptionTest {
                 }
             }
 
+            @Override
             public void eventsMissed(GENASubscription subscription, int numberOfMissedEvents) {
                 testAssertions.add(false);
             }
@@ -191,6 +193,7 @@ class EventProviderTest extends EventSubscriptionTest {
                 testAssertions.add(true);
             }
 
+            @Override
             public void eventReceived(GENASubscription subscription) {
                 if (subscription.getCurrentSequence().getValue() == 0) {
                     assertEquals("0", subscription.getCurrentValues().get("Target").toString());
@@ -205,6 +208,7 @@ class EventProviderTest extends EventSubscriptionTest {
                 }
             }
 
+            @Override
             public void eventsMissed(GENASubscription subscription, int numberOfMissedEvents) {
                 testAssertions.add(false);
             }
@@ -274,6 +278,7 @@ class EventProviderTest extends EventSubscriptionTest {
                 testAssertions.add(true);
             }
 
+            @Override
             public void eventReceived(GENASubscription subscription) {
                 if (subscription.getCurrentSequence().getValue() == 0) {
 
@@ -300,6 +305,7 @@ class EventProviderTest extends EventSubscriptionTest {
                 }
             }
 
+            @Override
             public void eventsMissed(GENASubscription subscription, int numberOfMissedEvents) {
                 testAssertions.add(false);
             }
@@ -384,6 +390,7 @@ class EventProviderTest extends EventSubscriptionTest {
                 testAssertions.add(true);
             }
 
+            @Override
             public void eventReceived(GENASubscription subscription) {
                 if (subscription.getCurrentSequence().getValue() == 0) {
 
@@ -410,6 +417,7 @@ class EventProviderTest extends EventSubscriptionTest {
                 }
             }
 
+            @Override
             public void eventsMissed(GENASubscription subscription, int numberOfMissedEvents) {
                 testAssertions.add(false);
             }

--- a/bundles/org.jupnp/src/test/java/org/jupnp/control/ActionInvokeIncomingTest.java
+++ b/bundles/org.jupnp/src/test/java/org/jupnp/control/ActionInvokeIncomingTest.java
@@ -178,6 +178,7 @@ class ActionInvokeIncomingTest {
             this.service = service;
         }
 
+        @Override
         public void run() {
             Action action = service.getAction("GetTarget");
 

--- a/bundles/org.jupnp/src/test/java/org/jupnp/data/SampleDeviceRoot.java
+++ b/bundles/org.jupnp/src/test/java/org/jupnp/data/SampleDeviceRoot.java
@@ -62,6 +62,7 @@ public class SampleDeviceRoot extends SampleDevice {
                 new DLNACaps(new String[] { "av-upload", "image-upload", "audio-upload" }));
     }
 
+    @Override
     public DeviceDetailsProvider getDeviceDetailsProvider() {
         return info -> getDeviceDetails();
     }

--- a/bundles/org.jupnp/src/test/java/org/jupnp/gena/EventXMLProcessingTest.java
+++ b/bundles/org.jupnp/src/test/java/org/jupnp/gena/EventXMLProcessingTest.java
@@ -77,12 +77,15 @@ class EventXMLProcessingTest {
                 throw new RuntimeException("TEST SUBSCRIPTION FAILED: " + ex);
             }
 
+            @Override
             public void ended(CancelReason reason) {
             }
 
+            @Override
             public void established() {
             }
 
+            @Override
             public void eventReceived() {
             }
         };

--- a/bundles/org.jupnp/src/test/java/org/jupnp/gena/OutgoingSubscriptionFailureTest.java
+++ b/bundles/org.jupnp/src/test/java/org/jupnp/gena/OutgoingSubscriptionFailureTest.java
@@ -99,10 +99,12 @@ class OutgoingSubscriptionFailureTest {
                 testAssertions.add(false);
             }
 
+            @Override
             public void eventReceived(GENASubscription subscription) {
                 testAssertions.add(false);
             }
 
+            @Override
             public void eventsMissed(GENASubscription subscription, int numberOfMissedEvents) {
                 testAssertions.add(false);
             }
@@ -159,12 +161,14 @@ class OutgoingSubscriptionFailureTest {
                 testAssertions.add(true);
             }
 
+            @Override
             public void eventReceived(GENASubscription subscription) {
                 assertEquals("0", subscription.getCurrentValues().get("Status").toString());
                 assertEquals("1", subscription.getCurrentValues().get("Target").toString());
                 testAssertions.add(true);
             }
 
+            @Override
             public void eventsMissed(GENASubscription subscription, int numberOfMissedEvents) {
                 assertEquals(2, numberOfMissedEvents);
                 testAssertions.add(true);

--- a/bundles/org.jupnp/src/test/java/org/jupnp/gena/OutgoingSubscriptionLifecycleTest.java
+++ b/bundles/org.jupnp/src/test/java/org/jupnp/gena/OutgoingSubscriptionLifecycleTest.java
@@ -92,12 +92,14 @@ class OutgoingSubscriptionLifecycleTest {
                 testAssertions.add(true);
             }
 
+            @Override
             public void eventReceived(GENASubscription subscription) {
                 assertEquals("0", subscription.getCurrentValues().get("Status").toString());
                 assertEquals("1", subscription.getCurrentValues().get("Target").toString());
                 testAssertions.add(true);
             }
 
+            @Override
             public void eventsMissed(GENASubscription subscription, int numberOfMissedEvents) {
                 testAssertions.add(false);
             }

--- a/bundles/org.jupnp/src/test/java/org/jupnp/mock/MockRouter.java
+++ b/bundles/org.jupnp/src/test/java/org/jupnp/mock/MockRouter.java
@@ -107,18 +107,22 @@ public class MockRouter implements Router {
         }
     }
 
+    @Override
     public void received(IncomingDatagramMessage msg) {
         incomingDatagramMessages.add(msg);
     }
 
+    @Override
     public void received(UpnpStream stream) {
         receivedUpnpStreams.add(stream);
     }
 
+    @Override
     public void send(OutgoingDatagramMessage msg) throws RouterException {
         outgoingDatagramMessages.add(msg);
     }
 
+    @Override
     public StreamResponseMessage send(StreamRequestMessage msg) throws RouterException {
         sentStreamRequestMessages.add(msg);
         counter++;
@@ -126,6 +130,7 @@ public class MockRouter implements Router {
                 : getStreamResponseMessage(msg);
     }
 
+    @Override
     public void broadcast(byte[] bytes) {
         broadcastedBytes.add(bytes);
     }

--- a/bundles/org.jupnp/src/test/java/org/jupnp/mock/MockUpnpService.java
+++ b/bundles/org.jupnp/src/test/java/org/jupnp/mock/MockUpnpService.java
@@ -132,26 +132,32 @@ public class MockUpnpService implements UpnpService {
         }
     }
 
+    @Override
     public UpnpServiceConfiguration getConfiguration() {
         return configuration;
     }
 
+    @Override
     public ControlPoint getControlPoint() {
         return controlPoint;
     }
 
+    @Override
     public ProtocolFactory getProtocolFactory() {
         return protocolFactory;
     }
 
+    @Override
     public Registry getRegistry() {
         return registry;
     }
 
+    @Override
     public MockRouter getRouter() {
         return router;
     }
 
+    @Override
     public void shutdown() {
         getRegistry().shutdown();
         getConfiguration().shutdown();

--- a/bundles/org.jupnp/src/test/java/org/jupnp/mock/MockUpnpServiceConfiguration.java
+++ b/bundles/org.jupnp/src/test/java/org/jupnp/mock/MockUpnpServiceConfiguration.java
@@ -102,28 +102,34 @@ public class MockUpnpServiceConfiguration extends DefaultUpnpServiceConfiguratio
 
             boolean terminated;
 
+            @Override
             public void shutdown() {
                 terminated = true;
             }
 
+            @Override
             public List<Runnable> shutdownNow() {
                 shutdown();
                 return null;
             }
 
+            @Override
             public boolean isShutdown() {
                 return terminated;
             }
 
+            @Override
             public boolean isTerminated() {
                 return terminated;
             }
 
+            @Override
             public boolean awaitTermination(long l, TimeUnit timeUnit) throws InterruptedException {
                 shutdown();
                 return terminated;
             }
 
+            @Override
             public void execute(Runnable runnable) {
                 runnable.run();
             }

--- a/bundles/org.jupnp/src/test/java/org/jupnp/service/QueueingThreadPoolExecutorTest.java
+++ b/bundles/org.jupnp/src/test/java/org/jupnp/service/QueueingThreadPoolExecutorTest.java
@@ -785,6 +785,7 @@ class QueueingThreadPoolExecutorTest {
             }
         }
 
+        @Override
         public void run() {
             logger.info("run job {}", uniqueId);
             runs.incrementAndGet();

--- a/bundles/org.jupnp/src/test/java/org/jupnp/ssdp/RegistryExpirationTest.java
+++ b/bundles/org.jupnp/src/test/java/org/jupnp/ssdp/RegistryExpirationTest.java
@@ -155,6 +155,7 @@ class RegistryExpirationTest {
     protected static class TestRunnable implements Runnable {
         boolean wasExecuted = false;
 
+        @Override
         public void run() {
             wasExecuted = true;
         }

--- a/tools/org.jupnp.tool/src/main/java/org/jupnp/tool/cli/MainCommandLogLevelValidator.java
+++ b/tools/org.jupnp.tool/src/main/java/org/jupnp/tool/cli/MainCommandLogLevelValidator.java
@@ -22,6 +22,7 @@ import com.beust.jcommander.ParameterException;
  * @author Jochen Hiller - Initial contribution
  */
 public class MainCommandLogLevelValidator implements IParameterValidator {
+    @Override
     public void validate(String name, String value) throws ParameterException {
         if (name.equals("--loglevel")) {
             if ((value.equalsIgnoreCase("TRACE")) || (value.equalsIgnoreCase("DEBUG"))

--- a/tools/org.jupnp.tool/src/main/java/org/jupnp/tool/cli/MainCommandMutlicastResponsePortValidator.java
+++ b/tools/org.jupnp.tool/src/main/java/org/jupnp/tool/cli/MainCommandMutlicastResponsePortValidator.java
@@ -25,6 +25,7 @@ public class MainCommandMutlicastResponsePortValidator implements IParameterVali
 
     private static final String ERROR_MSG = "Parameter --multicastResponsePort ";
 
+    @Override
     public void validate(String name, String value) throws ParameterException {
         if (name.equals("--multicastResponsePort")) {
             try {

--- a/tools/org.jupnp.tool/src/main/java/org/jupnp/tool/cli/MainCommandPoolConfigurationValidator.java
+++ b/tools/org.jupnp.tool/src/main/java/org/jupnp/tool/cli/MainCommandPoolConfigurationValidator.java
@@ -29,6 +29,7 @@ public class MainCommandPoolConfigurationValidator implements IParameterValidato
     private static final String ERROR_MSG = "Paramer --pool must be of format "
             + "'<mainPoolSize>,<asyncPoolSize>[,stats]'";
 
+    @Override
     public void validate(String name, String value) throws ParameterException {
         if (name.equals("--pool")) {
             // pool config is sth like "20,20,stats"

--- a/tools/org.jupnp.tool/src/main/java/org/jupnp/tool/cli/SearchCommandSortByValidator.java
+++ b/tools/org.jupnp.tool/src/main/java/org/jupnp/tool/cli/SearchCommandSortByValidator.java
@@ -22,6 +22,7 @@ import com.beust.jcommander.ParameterException;
  * @author Jochen Hiller - Initial contribution
  */
 public class SearchCommandSortByValidator implements IParameterValidator {
+    @Override
     public void validate(String name, String value) throws ParameterException {
         if (name.equals("--sort")) {
             if ((value.equalsIgnoreCase("ip")) || (value.equalsIgnoreCase("model"))

--- a/tools/org.jupnp.tool/src/test/java/org/jupnp/tool/cli/JUPnPToolWithRedirectionOfOutput.java
+++ b/tools/org.jupnp.tool/src/test/java/org/jupnp/tool/cli/JUPnPToolWithRedirectionOfOutput.java
@@ -44,6 +44,7 @@ public class JUPnPToolWithRedirectionOfOutput extends JUPnPTool {
     /**
      * Add an appender to Root-Logger with redirection to stdout.
      */
+    @Override
     protected void setLogging(String resourceName, String rootAppenderLogLevel) {
         super.setLogging(resourceName, rootAppenderLogLevel);
 


### PR DESCRIPTION
The `@Override` annotation makes it clear that these methods replace inherited behavior. It also prevents overloading mistakes and inheritance issues when method signatures change.