### PR TITLE
Create org.jupnp:tests JAR

### DIFF
--- a/bundles/org.jupnp/pom.xml
+++ b/bundles/org.jupnp/pom.xml
@@ -21,6 +21,16 @@
   <build>
     <plugins>
       <plugin>
+        <artifactId>maven-jar-plugin</artifactId>
+        <executions>
+          <execution>
+            <goals>
+              <goal>test-jar</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
           <includes>


### PR DESCRIPTION
This generates a JAR so it is possible to use the Mock classes in tests. These classes got moved to src/test in #181.
They are for instance [used](https://github.com/openhab/openhab-addons/blob/e68897c0a1c6d2912bf4ac3a8f8b468aa459acaf/itests/org.openhab.binding.wemo.tests/src/main/java/org/openhab/binding/wemo/internal/test/GenericWemoOSGiTest.java#L28) by the Wemo Binding Tests in openHAB.