### PR TITLE
Fix NPE when using `DefaultUpnpServiceConfiguration`

### DIFF
--- a/bundles/org.jupnp/src/main/java/org/jupnp/DefaultUpnpServiceConfiguration.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/DefaultUpnpServiceConfiguration.java
@@ -44,6 +44,7 @@ import org.jupnp.transport.impl.MulticastReceiverConfigurationImpl;
 import org.jupnp.transport.impl.MulticastReceiverImpl;
 import org.jupnp.transport.impl.NetworkAddressFactoryImpl;
 import org.jupnp.transport.impl.SOAPActionProcessorImpl;
+import org.jupnp.transport.impl.jetty.StreamClientConfigurationImpl;
 import org.jupnp.transport.spi.DatagramIO;
 import org.jupnp.transport.spi.DatagramProcessor;
 import org.jupnp.transport.spi.GENAEventProcessor;
@@ -157,6 +158,7 @@ public class DefaultUpnpServiceConfiguration implements UpnpServiceConfiguration
 
         namespace = createNamespace();
 
+        configuration = new StreamClientConfigurationImpl(defaultExecutorService);
         transportConfiguration = TransportConfigurationProvider.getDefaultTransportConfiguration();
     }
 


### PR DESCRIPTION
The `StreamClientConfiguration` variable is never assigned so let's do this to fix the NPE.

Fixes #144