### PR TITLE
Remove slf4j-jdk14 compile dependency

### DIFF
--- a/bom/compile/pom.xml
+++ b/bom/compile/pom.xml
@@ -59,11 +59,6 @@
       <artifactId>slf4j-api</artifactId>
       <version>${slf4j.version}</version>
     </dependency>
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-jdk14</artifactId>
-      <version>${slf4j.version}</version>
-    </dependency>
   </dependencies>
 
 </project>


### PR DESCRIPTION
The library should only depend on the slf4j-api and not on any logging implementation dependency.

See: https://www.slf4j.org/manual.html

In tests logback is still used so removing this dependency also fixes these warnings:

> SLF4J: Class path contains multiple SLF4J bindings.
> SLF4J: Found binding in [jar:file:/home/wouter/.m2/repository/org/slf4j/slf4j-jdk14/1.7.36/slf4j-jdk14-1.7.36.jar!/org/slf4j/impl/StaticLoggerBinder.class]
> SLF4J: Found binding in [jar:file:/home/wouter/.m2/repository/ch/qos/logback/logback-classic/1.2.13/logback-classic-1.2.13.jar!/org/slf4j/impl/StaticLoggerBinder.class]
> SLF4J: See http://www.slf4j.org/codes.html#multiple_bindings for an explanation.
> SLF4J: Actual binding is of type [org.slf4j.impl.JDK14LoggerFactory]