### PR TITLE
Fix non-optional dependency scopes

### DIFF
--- a/bundles/org.jupnp.osgi/pom.xml
+++ b/bundles/org.jupnp.osgi/pom.xml
@@ -23,6 +23,13 @@
       <groupId>org.jupnp</groupId>
       <artifactId>org.jupnp</artifactId>
       <version>${project.version}</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>${slf4j.version}</version>
+      <scope>compile</scope>
     </dependency>
   </dependencies>
 

--- a/bundles/org.jupnp.support/pom.xml
+++ b/bundles/org.jupnp.support/pom.xml
@@ -24,6 +24,13 @@
       <groupId>org.jupnp</groupId>
       <artifactId>org.jupnp</artifactId>
       <version>${project.version}</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>${slf4j.version}</version>
+      <scope>compile</scope>
     </dependency>
   </dependencies>
 

--- a/bundles/org.jupnp/pom.xml
+++ b/bundles/org.jupnp/pom.xml
@@ -18,6 +18,15 @@
     <basedirRoot>../..</basedirRoot>
   </properties>
 
+  <dependencies>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>${slf4j.version}</version>
+      <scope>compile</scope>
+    </dependency>
+  </dependencies>
+
   <build>
     <plugins>
       <plugin>


### PR DESCRIPTION
Uses the 'compile' scope with the org.jupnp and slf4j-api dependencies. These dependencies are not optional and currently have the 'provided' scope. There will be fewer issues when these dependencies are resolved through transitivity.