### PR TITLE
Remove redundant boxing

### DIFF
--- a/bundles/org.jupnp.support/src/main/java/org/jupnp/support/model/Res.java
+++ b/bundles/org.jupnp.support/src/main/java/org/jupnp/support/model/Res.java
@@ -179,13 +179,13 @@ public class Res {
 
     public int getResolutionX() {
         return getResolution() != null && getResolution().split("x").length == 2
-                ? Integer.valueOf(getResolution().split("x")[0])
+                ? Integer.parseInt(getResolution().split("x")[0])
                 : 0;
     }
 
     public int getResolutionY() {
         return getResolution() != null && getResolution().split("x").length == 2
-                ? Integer.valueOf(getResolution().split("x")[1])
+                ? Integer.parseInt(getResolution().split("x")[1])
                 : 0;
     }
 

--- a/bundles/org.jupnp/src/main/java/org/jupnp/binding/annotations/AnnotationStateVariableBinder.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/binding/annotations/AnnotationStateVariableBinder.java
@@ -127,7 +127,7 @@ public class AnnotationStateVariableBinder {
 
                 long v;
                 try {
-                    v = Long.valueOf(defaultValue);
+                    v = Long.parseLong(defaultValue);
                 } catch (Exception ex) {
                     throw new LocalServiceBindingException("Default value '" + defaultValue
                             + "' is not numeric (for range checking) of: " + getName());

--- a/bundles/org.jupnp/src/main/java/org/jupnp/binding/xml/UDA10DeviceDescriptorBinderImpl.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/binding/xml/UDA10DeviceDescriptorBinderImpl.java
@@ -205,14 +205,14 @@ public class UDA10DeviceDescriptorBinderImpl implements DeviceDescriptorBinder, 
                     SpecificationViolationReporter.report("Unsupported UDA major version, ignoring: " + version);
                     version = "1";
                 }
-                descriptor.udaVersion.major = Integer.valueOf(version);
+                descriptor.udaVersion.major = Integer.parseInt(version);
             } else if (ELEMENT.minor.equals(specVersionChild)) {
                 String version = XMLUtil.getTextContent(specVersionChild).trim();
                 if (!version.equals("0")) {
                     SpecificationViolationReporter.report("Unsupported UDA minor version, ignoring: " + version);
                     version = "0";
                 }
-                descriptor.udaVersion.minor = Integer.valueOf(version);
+                descriptor.udaVersion.minor = Integer.parseInt(version);
             }
 
         }
@@ -297,13 +297,13 @@ public class UDA10DeviceDescriptorBinderImpl implements DeviceDescriptorBinder, 
                     }
 
                     if (ELEMENT.width.equals(iconChild)) {
-                        icon.width = (Integer.valueOf(XMLUtil.getTextContent(iconChild)));
+                        icon.width = (Integer.parseInt(XMLUtil.getTextContent(iconChild)));
                     } else if (ELEMENT.height.equals(iconChild)) {
-                        icon.height = (Integer.valueOf(XMLUtil.getTextContent(iconChild)));
+                        icon.height = (Integer.parseInt(XMLUtil.getTextContent(iconChild)));
                     } else if (ELEMENT.depth.equals(iconChild)) {
                         String depth = XMLUtil.getTextContent(iconChild);
                         try {
-                            icon.depth = (Integer.valueOf(depth));
+                            icon.depth = (Integer.parseInt(depth));
                         } catch (NumberFormatException ex) {
                             SpecificationViolationReporter.report("Invalid icon depth '{}', using 16 as default: {}",
                                     depth, ex);

--- a/bundles/org.jupnp/src/main/java/org/jupnp/binding/xml/UDA10DeviceDescriptorBinderSAXImpl.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/binding/xml/UDA10DeviceDescriptorBinderSAXImpl.java
@@ -141,7 +141,7 @@ public class UDA10DeviceDescriptorBinderSAXImpl extends UDA10DeviceDescriptorBin
                                 .report("Unsupported UDA major version, ignoring: " + majorVersion);
                         majorVersion = "1";
                     }
-                    getInstance().major = Integer.valueOf(majorVersion);
+                    getInstance().major = Integer.parseInt(majorVersion);
                     break;
                 case minor:
                     String minorVersion = getCharacters().trim();
@@ -150,7 +150,7 @@ public class UDA10DeviceDescriptorBinderSAXImpl extends UDA10DeviceDescriptorBin
                                 .report("Unsupported UDA minor version, ignoring: " + minorVersion);
                         minorVersion = "0";
                     }
-                    getInstance().minor = Integer.valueOf(minorVersion);
+                    getInstance().minor = Integer.parseInt(minorVersion);
                     break;
             }
         }
@@ -285,14 +285,14 @@ public class UDA10DeviceDescriptorBinderSAXImpl extends UDA10DeviceDescriptorBin
         public void endElement(ELEMENT element) throws SAXException {
             switch (element) {
                 case width:
-                    getInstance().width = Integer.valueOf(getCharacters());
+                    getInstance().width = Integer.parseInt(getCharacters());
                     break;
                 case height:
-                    getInstance().height = Integer.valueOf(getCharacters());
+                    getInstance().height = Integer.parseInt(getCharacters());
                     break;
                 case depth:
                     try {
-                        getInstance().depth = Integer.valueOf(getCharacters());
+                        getInstance().depth = Integer.parseInt(getCharacters());
                     } catch (NumberFormatException ex) {
                         SpecificationViolationReporter.report("Invalid icon depth '{}', using 16 as default: {}",
                                 getCharacters(), ex);

--- a/bundles/org.jupnp/src/main/java/org/jupnp/http/CacheControl.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/http/CacheControl.java
@@ -169,12 +169,12 @@ public class CacheControl {
                 if (value == null) {
                     throw new IllegalArgumentException("CacheControl max-age header does not have a value: " + value);
                 }
-                result.setMaxAge(Integer.valueOf(value));
+                result.setMaxAge(Integer.parseInt(value));
             } else if ("s-maxage".equals(lowercase)) {
                 if (value == null) {
                     throw new IllegalArgumentException("CacheControl s-maxage header does not have a value: " + value);
                 }
-                result.setSharedMaxAge(Integer.valueOf(value));
+                result.setSharedMaxAge(Integer.parseInt(value));
             } else if ("no-transform".equals(lowercase)) {
                 result.setNoTransform(true);
             } else if ("must-revalidate".equals(lowercase)) {

--- a/bundles/org.jupnp/src/main/java/org/jupnp/model/gena/LocalGENASubscription.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/model/gena/LocalGENASubscription.java
@@ -212,8 +212,8 @@ public abstract class LocalGENASubscription extends GENASubscription<LocalServic
 
             if (stateVariable.isModeratedNumericType() && lastSentNumericValue.get(stateVariableName) != null) {
 
-                long oldValue = Long.valueOf(lastSentNumericValue.get(stateVariableName));
-                long newValue = Long.valueOf(stateVariableValue.toString());
+                long oldValue = lastSentNumericValue.get(stateVariableName);
+                long newValue = Long.parseLong(stateVariableValue.toString());
                 long minDelta = stateVariable.getEventDetails().getEventMinimumDelta();
 
                 if (newValue > oldValue && newValue - oldValue < minDelta) {

--- a/bundles/org.jupnp/src/main/java/org/jupnp/model/message/header/HostHeader.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/model/message/header/HostHeader.java
@@ -44,7 +44,7 @@ public class HostHeader extends UpnpHeader<HostPort> {
         if (s.contains(":")) {
             // We have a port in the header, so we have to use that instead of the UDA default
             try {
-                this.port = Integer.valueOf(s.substring(s.indexOf(":") + 1));
+                this.port = Integer.parseInt(s.substring(s.indexOf(":") + 1));
                 this.group = s.substring(0, s.indexOf(":"));
                 setValue(new HostPort(group, port));
             } catch (NumberFormatException ex) {

--- a/bundles/org.jupnp/src/main/java/org/jupnp/model/types/DeviceType.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/model/types/DeviceType.java
@@ -100,7 +100,7 @@ public class DeviceType {
             // Now try a generic DeviceType parse
             Matcher matcher = PATTERN.matcher(s);
             if (matcher.matches()) {
-                return new DeviceType(matcher.group(1), matcher.group(2), Integer.valueOf(matcher.group(3)));
+                return new DeviceType(matcher.group(1), matcher.group(2), Integer.parseInt(matcher.group(3)));
             }
 
             // TODO: UPNP VIOLATION: Escient doesn't provide any device type token
@@ -108,7 +108,7 @@ public class DeviceType {
             matcher = Pattern.compile("urn:(" + Constants.REGEX_NAMESPACE + "):device::([0-9]+).*").matcher(s);
             if (matcher.matches() && matcher.groupCount() >= 2) {
                 SpecificationViolationReporter.report("No device type token, defaulting to " + UNKNOWN + ": " + s);
-                return new DeviceType(matcher.group(1), UNKNOWN, Integer.valueOf(matcher.group(2)));
+                return new DeviceType(matcher.group(1), UNKNOWN, Integer.parseInt(matcher.group(2)));
             }
 
             // TODO: UPNP VIOLATION: EyeTV Netstream uses colons in device type token
@@ -118,7 +118,7 @@ public class DeviceType {
                 String cleanToken = matcher.group(2).replaceAll("[^a-zA-Z_0-9\\-]", "-");
                 SpecificationViolationReporter.report("Replacing invalid device type token '{}' with: {}",
                         matcher.group(2), cleanToken);
-                return new DeviceType(matcher.group(1), cleanToken, Integer.valueOf(matcher.group(3)));
+                return new DeviceType(matcher.group(1), cleanToken, Integer.parseInt(matcher.group(3)));
             }
         } catch (RuntimeException e) {
             throw new InvalidValueException(

--- a/bundles/org.jupnp/src/main/java/org/jupnp/model/types/ServiceType.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/model/types/ServiceType.java
@@ -106,12 +106,12 @@ public class ServiceType {
         try {
             Matcher matcher = ServiceType.PATTERN.matcher(s);
             if (matcher.matches() && matcher.groupCount() >= 3) {
-                return new ServiceType(matcher.group(1), matcher.group(2), Integer.valueOf(matcher.group(3)));
+                return new ServiceType(matcher.group(1), matcher.group(2), Integer.parseInt(matcher.group(3)));
             }
 
             matcher = ServiceType.BROKEN_PATTERN.matcher(s);
             if (matcher.matches() && matcher.groupCount() >= 3) {
-                return new ServiceType(matcher.group(1), matcher.group(2), Integer.valueOf(matcher.group(3)));
+                return new ServiceType(matcher.group(1), matcher.group(2), Integer.parseInt(matcher.group(3)));
             }
 
             // TODO: UPNP VIOLATION: EyeTV Netstream uses colons in service type token
@@ -121,7 +121,7 @@ public class ServiceType {
                 String cleanToken = matcher.group(2).replaceAll("[^a-zA-Z_0-9\\-]", "-");
                 SpecificationViolationReporter.report("Replacing invalid service type token '{}' with: {}",
                         matcher.group(2), cleanToken);
-                return new ServiceType(matcher.group(1), cleanToken, Integer.valueOf(matcher.group(3)));
+                return new ServiceType(matcher.group(1), cleanToken, Integer.parseInt(matcher.group(3)));
             }
 
             // TODO: UPNP VIOLATION: Ceyton InfiniTV uses colons in service type token and 'serviceId' instead of
@@ -132,7 +132,7 @@ public class ServiceType {
                 String cleanToken = matcher.group(2).replaceAll("[^a-zA-Z_0-9\\-]", "-");
                 SpecificationViolationReporter.report("Replacing invalid service type token '{}' with: {}",
                         matcher.group(2), cleanToken);
-                return new ServiceType(matcher.group(1), cleanToken, Integer.valueOf(matcher.group(3)));
+                return new ServiceType(matcher.group(1), cleanToken, Integer.parseInt(matcher.group(3)));
             }
         } catch (RuntimeException e) {
             throw new InvalidValueException(

--- a/bundles/org.jupnp/src/main/java/org/jupnp/model/types/UDADeviceType.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/model/types/UDADeviceType.java
@@ -47,7 +47,7 @@ public class UDADeviceType extends DeviceType {
 
         try {
             if (matcher.matches()) {
-                return new UDADeviceType(matcher.group(1), Integer.valueOf(matcher.group(2)));
+                return new UDADeviceType(matcher.group(1), Integer.parseInt(matcher.group(2)));
             }
         } catch (RuntimeException e) {
             throw new InvalidValueException(

--- a/bundles/org.jupnp/src/main/java/org/jupnp/model/types/UDAServiceType.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/model/types/UDAServiceType.java
@@ -47,7 +47,7 @@ public class UDAServiceType extends ServiceType {
 
         try {
             if (matcher.matches())
-                return new UDAServiceType(matcher.group(1), Integer.valueOf(matcher.group(2)));
+                return new UDAServiceType(matcher.group(1), Integer.parseInt(matcher.group(2)));
         } catch (RuntimeException e) {
             throw new InvalidValueException(
                     String.format("Can't parse UDA service type string (namespace/type/version) '%s'", s), e);

--- a/bundles/org.jupnp/src/main/java/org/jupnp/transport/impl/SOAPActionProcessorImpl.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/transport/impl/SOAPActionProcessorImpl.java
@@ -453,7 +453,7 @@ public class SOAPActionProcessorImpl extends PooledXmlProcessor implements SOAPA
 
         if (errorCode != null) {
             try {
-                int numericCode = Integer.valueOf(errorCode);
+                int numericCode = Integer.parseInt(errorCode);
                 ErrorCode standardErrorCode = ErrorCode.getByCode(numericCode);
                 if (standardErrorCode != null) {
                     log.trace("Reading fault element: {} - {}", standardErrorCode.getCode(), errorDescription);


### PR DESCRIPTION
Parsing to primitives directly prevents the overhead of creating objects and unneccessary garbage collection.