### PR TITLE
Use protected modifier with constructor of abstract classes

### DIFF
--- a/bundles/org.jupnp.support/src/main/java/org/jupnp/support/avtransport/callback/GetCurrentTransportActions.java
+++ b/bundles/org.jupnp.support/src/main/java/org/jupnp/support/avtransport/callback/GetCurrentTransportActions.java
@@ -27,11 +27,11 @@ import org.jupnp.support.model.TransportAction;
  */
 public abstract class GetCurrentTransportActions extends ActionCallback {
 
-    public GetCurrentTransportActions(Service<?, ?> service) {
+    protected GetCurrentTransportActions(Service<?, ?> service) {
         this(new UnsignedIntegerFourBytes(0), service);
     }
 
-    public GetCurrentTransportActions(UnsignedIntegerFourBytes instanceId, Service<?, ?> service) {
+    protected GetCurrentTransportActions(UnsignedIntegerFourBytes instanceId, Service<?, ?> service) {
         super(new ActionInvocation<>(service.getAction("GetCurrentTransportActions")));
         getActionInvocation().setInput("InstanceID", instanceId);
     }

--- a/bundles/org.jupnp.support/src/main/java/org/jupnp/support/avtransport/callback/GetDeviceCapabilities.java
+++ b/bundles/org.jupnp.support/src/main/java/org/jupnp/support/avtransport/callback/GetDeviceCapabilities.java
@@ -27,11 +27,11 @@ import org.jupnp.support.model.DeviceCapabilities;
  */
 public abstract class GetDeviceCapabilities extends ActionCallback {
 
-    public GetDeviceCapabilities(Service<?, ?> service) {
+    protected GetDeviceCapabilities(Service<?, ?> service) {
         this(new UnsignedIntegerFourBytes(0), service);
     }
 
-    public GetDeviceCapabilities(UnsignedIntegerFourBytes instanceId, Service<?, ?> service) {
+    protected GetDeviceCapabilities(UnsignedIntegerFourBytes instanceId, Service<?, ?> service) {
         super(new ActionInvocation<>(service.getAction("GetDeviceCapabilities")));
         getActionInvocation().setInput("InstanceID", instanceId);
     }

--- a/bundles/org.jupnp.support/src/main/java/org/jupnp/support/avtransport/callback/GetMediaInfo.java
+++ b/bundles/org.jupnp.support/src/main/java/org/jupnp/support/avtransport/callback/GetMediaInfo.java
@@ -27,11 +27,11 @@ import org.jupnp.support.model.MediaInfo;
  */
 public abstract class GetMediaInfo extends ActionCallback {
 
-    public GetMediaInfo(Service<?, ?> service) {
+    protected GetMediaInfo(Service<?, ?> service) {
         this(new UnsignedIntegerFourBytes(0), service);
     }
 
-    public GetMediaInfo(UnsignedIntegerFourBytes instanceId, Service<?, ?> service) {
+    protected GetMediaInfo(UnsignedIntegerFourBytes instanceId, Service<?, ?> service) {
         super(new ActionInvocation<>(service.getAction("GetMediaInfo")));
         getActionInvocation().setInput("InstanceID", instanceId);
     }

--- a/bundles/org.jupnp.support/src/main/java/org/jupnp/support/avtransport/callback/GetPositionInfo.java
+++ b/bundles/org.jupnp.support/src/main/java/org/jupnp/support/avtransport/callback/GetPositionInfo.java
@@ -27,11 +27,11 @@ import org.jupnp.support.model.PositionInfo;
  */
 public abstract class GetPositionInfo extends ActionCallback {
 
-    public GetPositionInfo(Service<?, ?> service) {
+    protected GetPositionInfo(Service<?, ?> service) {
         this(new UnsignedIntegerFourBytes(0), service);
     }
 
-    public GetPositionInfo(UnsignedIntegerFourBytes instanceId, Service<?, ?> service) {
+    protected GetPositionInfo(UnsignedIntegerFourBytes instanceId, Service<?, ?> service) {
         super(new ActionInvocation<>(service.getAction("GetPositionInfo")));
         getActionInvocation().setInput("InstanceID", instanceId);
     }

--- a/bundles/org.jupnp.support/src/main/java/org/jupnp/support/avtransport/callback/GetTransportInfo.java
+++ b/bundles/org.jupnp.support/src/main/java/org/jupnp/support/avtransport/callback/GetTransportInfo.java
@@ -27,11 +27,11 @@ import org.jupnp.support.model.TransportInfo;
  */
 public abstract class GetTransportInfo extends ActionCallback {
 
-    public GetTransportInfo(Service<?, ?> service) {
+    protected GetTransportInfo(Service<?, ?> service) {
         this(new UnsignedIntegerFourBytes(0), service);
     }
 
-    public GetTransportInfo(UnsignedIntegerFourBytes instanceId, Service<?, ?> service) {
+    protected GetTransportInfo(UnsignedIntegerFourBytes instanceId, Service<?, ?> service) {
         super(new ActionInvocation<>(service.getAction("GetTransportInfo")));
         getActionInvocation().setInput("InstanceID", instanceId);
     }

--- a/bundles/org.jupnp.support/src/main/java/org/jupnp/support/avtransport/callback/Next.java
+++ b/bundles/org.jupnp.support/src/main/java/org/jupnp/support/avtransport/callback/Next.java
@@ -39,11 +39,11 @@ public abstract class Next extends ActionCallback {
         super(actionInvocation);
     }
 
-    public Next(Service<?, ?> service) {
+    protected Next(Service<?, ?> service) {
         this(new UnsignedIntegerFourBytes(0), service);
     }
 
-    public Next(UnsignedIntegerFourBytes instanceId, Service<?, ?> service) {
+    protected Next(UnsignedIntegerFourBytes instanceId, Service<?, ?> service) {
         super(new ActionInvocation<>(service.getAction("Next")));
         getActionInvocation().setInput("InstanceID", instanceId);
     }

--- a/bundles/org.jupnp.support/src/main/java/org/jupnp/support/avtransport/callback/Pause.java
+++ b/bundles/org.jupnp.support/src/main/java/org/jupnp/support/avtransport/callback/Pause.java
@@ -39,11 +39,11 @@ public abstract class Pause extends ActionCallback {
         super(actionInvocation);
     }
 
-    public Pause(Service<?, ?> service) {
+    protected Pause(Service<?, ?> service) {
         this(new UnsignedIntegerFourBytes(0), service);
     }
 
-    public Pause(UnsignedIntegerFourBytes instanceId, Service<?, ?> service) {
+    protected Pause(UnsignedIntegerFourBytes instanceId, Service<?, ?> service) {
         super(new ActionInvocation<>(service.getAction("Pause")));
         getActionInvocation().setInput("InstanceID", instanceId);
     }

--- a/bundles/org.jupnp.support/src/main/java/org/jupnp/support/avtransport/callback/Play.java
+++ b/bundles/org.jupnp.support/src/main/java/org/jupnp/support/avtransport/callback/Play.java
@@ -30,19 +30,19 @@ public abstract class Play extends ActionCallback {
 
     private final Logger logger = LoggerFactory.getLogger(Play.class);
 
-    public Play(Service<?, ?> service) {
+    protected Play(Service<?, ?> service) {
         this(new UnsignedIntegerFourBytes(0), service, "1");
     }
 
-    public Play(Service<?, ?> service, String speed) {
+    protected Play(Service<?, ?> service, String speed) {
         this(new UnsignedIntegerFourBytes(0), service, speed);
     }
 
-    public Play(UnsignedIntegerFourBytes instanceId, Service<?, ?> service) {
+    protected Play(UnsignedIntegerFourBytes instanceId, Service<?, ?> service) {
         this(instanceId, service, "1");
     }
 
-    public Play(UnsignedIntegerFourBytes instanceId, Service<?, ?> service, String speed) {
+    protected Play(UnsignedIntegerFourBytes instanceId, Service<?, ?> service, String speed) {
         super(new ActionInvocation<>(service.getAction("Play")));
         getActionInvocation().setInput("InstanceID", instanceId);
         getActionInvocation().setInput("Speed", speed);

--- a/bundles/org.jupnp.support/src/main/java/org/jupnp/support/avtransport/callback/Previous.java
+++ b/bundles/org.jupnp.support/src/main/java/org/jupnp/support/avtransport/callback/Previous.java
@@ -39,11 +39,11 @@ public abstract class Previous extends ActionCallback {
         super(actionInvocation);
     }
 
-    public Previous(Service<?, ?> service) {
+    protected Previous(Service<?, ?> service) {
         this(new UnsignedIntegerFourBytes(0), service);
     }
 
-    public Previous(UnsignedIntegerFourBytes instanceId, Service<?, ?> service) {
+    protected Previous(UnsignedIntegerFourBytes instanceId, Service<?, ?> service) {
         super(new ActionInvocation<>(service.getAction("Previous")));
         getActionInvocation().setInput("InstanceID", instanceId);
     }

--- a/bundles/org.jupnp.support/src/main/java/org/jupnp/support/avtransport/callback/Seek.java
+++ b/bundles/org.jupnp.support/src/main/java/org/jupnp/support/avtransport/callback/Seek.java
@@ -31,19 +31,19 @@ public abstract class Seek extends ActionCallback {
 
     private final Logger logger = LoggerFactory.getLogger(Seek.class);
 
-    public Seek(Service<?, ?> service, String relativeTimeTarget) {
+    protected Seek(Service<?, ?> service, String relativeTimeTarget) {
         this(new UnsignedIntegerFourBytes(0), service, SeekMode.REL_TIME, relativeTimeTarget);
     }
 
-    public Seek(UnsignedIntegerFourBytes instanceId, Service<?, ?> service, String relativeTimeTarget) {
+    protected Seek(UnsignedIntegerFourBytes instanceId, Service<?, ?> service, String relativeTimeTarget) {
         this(instanceId, service, SeekMode.REL_TIME, relativeTimeTarget);
     }
 
-    public Seek(Service<?, ?> service, SeekMode mode, String target) {
+    protected Seek(Service<?, ?> service, SeekMode mode, String target) {
         this(new UnsignedIntegerFourBytes(0), service, mode, target);
     }
 
-    public Seek(UnsignedIntegerFourBytes instanceId, Service<?, ?> service, SeekMode mode, String target) {
+    protected Seek(UnsignedIntegerFourBytes instanceId, Service<?, ?> service, SeekMode mode, String target) {
         super(new ActionInvocation<>(service.getAction("Seek")));
         getActionInvocation().setInput("InstanceID", instanceId);
         getActionInvocation().setInput("Unit", mode.name());

--- a/bundles/org.jupnp.support/src/main/java/org/jupnp/support/avtransport/callback/SetAVTransportURI.java
+++ b/bundles/org.jupnp.support/src/main/java/org/jupnp/support/avtransport/callback/SetAVTransportURI.java
@@ -30,19 +30,20 @@ public abstract class SetAVTransportURI extends ActionCallback {
 
     private final Logger logger = LoggerFactory.getLogger(SetAVTransportURI.class);
 
-    public SetAVTransportURI(Service<?, ?> service, String uri) {
+    protected SetAVTransportURI(Service<?, ?> service, String uri) {
         this(new UnsignedIntegerFourBytes(0), service, uri, null);
     }
 
-    public SetAVTransportURI(Service<?, ?> service, String uri, String metadata) {
+    protected SetAVTransportURI(Service<?, ?> service, String uri, String metadata) {
         this(new UnsignedIntegerFourBytes(0), service, uri, metadata);
     }
 
-    public SetAVTransportURI(UnsignedIntegerFourBytes instanceId, Service<?, ?> service, String uri) {
+    protected SetAVTransportURI(UnsignedIntegerFourBytes instanceId, Service<?, ?> service, String uri) {
         this(instanceId, service, uri, null);
     }
 
-    public SetAVTransportURI(UnsignedIntegerFourBytes instanceId, Service<?, ?> service, String uri, String metadata) {
+    protected SetAVTransportURI(UnsignedIntegerFourBytes instanceId, Service<?, ?> service, String uri,
+            String metadata) {
         super(new ActionInvocation<>(service.getAction("SetAVTransportURI")));
         logger.debug("Creating SetAVTransportURI action for URI: {}", uri);
         getActionInvocation().setInput("InstanceID", instanceId);

--- a/bundles/org.jupnp.support/src/main/java/org/jupnp/support/avtransport/callback/SetPlayMode.java
+++ b/bundles/org.jupnp.support/src/main/java/org/jupnp/support/avtransport/callback/SetPlayMode.java
@@ -31,11 +31,11 @@ public abstract class SetPlayMode extends ActionCallback {
 
     private final Logger logger = LoggerFactory.getLogger(SetPlayMode.class);
 
-    public SetPlayMode(Service<?, ?> service, PlayMode playMode) {
+    protected SetPlayMode(Service<?, ?> service, PlayMode playMode) {
         this(new UnsignedIntegerFourBytes(0), service, playMode);
     }
 
-    public SetPlayMode(UnsignedIntegerFourBytes instanceId, Service<?, ?> service, PlayMode playMode) {
+    protected SetPlayMode(UnsignedIntegerFourBytes instanceId, Service<?, ?> service, PlayMode playMode) {
         super(new ActionInvocation<>(service.getAction("SetPlayMode")));
         getActionInvocation().setInput("InstanceID", instanceId);
         getActionInvocation().setInput("NewPlayMode", playMode.toString());

--- a/bundles/org.jupnp.support/src/main/java/org/jupnp/support/avtransport/callback/Stop.java
+++ b/bundles/org.jupnp.support/src/main/java/org/jupnp/support/avtransport/callback/Stop.java
@@ -30,11 +30,11 @@ public abstract class Stop extends ActionCallback {
 
     private final Logger logger = LoggerFactory.getLogger(Stop.class);
 
-    public Stop(Service<?, ?> service) {
+    protected Stop(Service<?, ?> service) {
         this(new UnsignedIntegerFourBytes(0), service);
     }
 
-    public Stop(UnsignedIntegerFourBytes instanceId, Service<?, ?> service) {
+    protected Stop(UnsignedIntegerFourBytes instanceId, Service<?, ?> service) {
         super(new ActionInvocation<>(service.getAction("Stop")));
         getActionInvocation().setInput("InstanceID", instanceId);
     }

--- a/bundles/org.jupnp.support/src/main/java/org/jupnp/support/avtransport/impl/state/AbstractState.java
+++ b/bundles/org.jupnp.support/src/main/java/org/jupnp/support/avtransport/impl/state/AbstractState.java
@@ -22,7 +22,7 @@ public abstract class AbstractState<T extends AVTransport> {
 
     private T transport;
 
-    public AbstractState(T transport) {
+    protected AbstractState(T transport) {
         this.transport = transport;
     }
 

--- a/bundles/org.jupnp.support/src/main/java/org/jupnp/support/avtransport/impl/state/NoMediaPresent.java
+++ b/bundles/org.jupnp.support/src/main/java/org/jupnp/support/avtransport/impl/state/NoMediaPresent.java
@@ -33,7 +33,7 @@ public abstract class NoMediaPresent<T extends AVTransport> extends AbstractStat
 
     private final Logger logger = LoggerFactory.getLogger(NoMediaPresent.class);
 
-    public NoMediaPresent(T transport) {
+    protected NoMediaPresent(T transport) {
         super(transport);
     }
 

--- a/bundles/org.jupnp.support/src/main/java/org/jupnp/support/avtransport/impl/state/PausedPlay.java
+++ b/bundles/org.jupnp.support/src/main/java/org/jupnp/support/avtransport/impl/state/PausedPlay.java
@@ -33,7 +33,7 @@ public abstract class PausedPlay<T extends AVTransport> extends AbstractState<T>
 
     private final Logger logger = LoggerFactory.getLogger(PausedPlay.class);
 
-    public PausedPlay(T transport) {
+    protected PausedPlay(T transport) {
         super(transport);
     }
 

--- a/bundles/org.jupnp.support/src/main/java/org/jupnp/support/avtransport/impl/state/Playing.java
+++ b/bundles/org.jupnp.support/src/main/java/org/jupnp/support/avtransport/impl/state/Playing.java
@@ -34,7 +34,7 @@ public abstract class Playing<T extends AVTransport> extends AbstractState<T> {
 
     private final Logger logger = LoggerFactory.getLogger(Playing.class);
 
-    public Playing(T transport) {
+    protected Playing(T transport) {
         super(transport);
     }
 

--- a/bundles/org.jupnp.support/src/main/java/org/jupnp/support/avtransport/impl/state/Stopped.java
+++ b/bundles/org.jupnp.support/src/main/java/org/jupnp/support/avtransport/impl/state/Stopped.java
@@ -34,7 +34,7 @@ public abstract class Stopped<T extends AVTransport> extends AbstractState<T> {
 
     private final Logger logger = LoggerFactory.getLogger(Stopped.class);
 
-    public Stopped(T transport) {
+    protected Stopped(T transport) {
         super(transport);
     }
 

--- a/bundles/org.jupnp.support/src/main/java/org/jupnp/support/connectionmanager/callback/ConnectionComplete.java
+++ b/bundles/org.jupnp.support/src/main/java/org/jupnp/support/connectionmanager/callback/ConnectionComplete.java
@@ -26,7 +26,7 @@ import org.jupnp.model.meta.Service;
  */
 public abstract class ConnectionComplete extends ActionCallback {
 
-    public ConnectionComplete(Service<?, ?> service, int connectionID) {
+    protected ConnectionComplete(Service<?, ?> service, int connectionID) {
         this(service, null, connectionID);
     }
 

--- a/bundles/org.jupnp.support/src/main/java/org/jupnp/support/connectionmanager/callback/GetCurrentConnectionInfo.java
+++ b/bundles/org.jupnp.support/src/main/java/org/jupnp/support/connectionmanager/callback/GetCurrentConnectionInfo.java
@@ -32,7 +32,7 @@ import org.jupnp.support.model.ProtocolInfo;
  */
 public abstract class GetCurrentConnectionInfo extends ActionCallback {
 
-    public GetCurrentConnectionInfo(Service<?, ?> service, int connectionID) {
+    protected GetCurrentConnectionInfo(Service<?, ?> service, int connectionID) {
         this(service, null, connectionID);
     }
 

--- a/bundles/org.jupnp.support/src/main/java/org/jupnp/support/connectionmanager/callback/GetProtocolInfo.java
+++ b/bundles/org.jupnp.support/src/main/java/org/jupnp/support/connectionmanager/callback/GetProtocolInfo.java
@@ -30,7 +30,7 @@ import org.jupnp.support.model.ProtocolInfos;
  */
 public abstract class GetProtocolInfo extends ActionCallback {
 
-    public GetProtocolInfo(Service<?, ?> service) {
+    protected GetProtocolInfo(Service<?, ?> service) {
         this(service, null);
     }
 

--- a/bundles/org.jupnp.support/src/main/java/org/jupnp/support/connectionmanager/callback/PrepareForConnection.java
+++ b/bundles/org.jupnp.support/src/main/java/org/jupnp/support/connectionmanager/callback/PrepareForConnection.java
@@ -30,12 +30,12 @@ import org.jupnp.support.model.ProtocolInfo;
  */
 public abstract class PrepareForConnection extends ActionCallback {
 
-    public PrepareForConnection(Service<?, ?> service, ProtocolInfo remoteProtocolInfo,
+    protected PrepareForConnection(Service<?, ?> service, ProtocolInfo remoteProtocolInfo,
             ServiceReference peerConnectionManager, int peerConnectionID, ConnectionInfo.Direction direction) {
         this(service, null, remoteProtocolInfo, peerConnectionManager, peerConnectionID, direction);
     }
 
-    public PrepareForConnection(Service<?, ?> service, ControlPoint controlPoint, ProtocolInfo remoteProtocolInfo,
+    protected PrepareForConnection(Service<?, ?> service, ControlPoint controlPoint, ProtocolInfo remoteProtocolInfo,
             ServiceReference peerConnectionManager, int peerConnectionID, ConnectionInfo.Direction direction) {
         super(new ActionInvocation<>(service.getAction("PrepareForConnection")), controlPoint);
 

--- a/bundles/org.jupnp.support/src/main/java/org/jupnp/support/contentdirectory/callback/Browse.java
+++ b/bundles/org.jupnp.support/src/main/java/org/jupnp/support/contentdirectory/callback/Browse.java
@@ -61,14 +61,14 @@ public abstract class Browse extends ActionCallback {
     /**
      * Browse with first result 0 and {@link #getDefaultMaxResults()}, filters with {@link #CAPS_WILDCARD}.
      */
-    public Browse(Service<?, ?> service, String containerId, BrowseFlag flag) {
+    protected Browse(Service<?, ?> service, String containerId, BrowseFlag flag) {
         this(service, containerId, flag, CAPS_WILDCARD, 0, null);
     }
 
     /**
      * @param maxResults Can be <code>null</code>, then {@link #getDefaultMaxResults()} is used.
      */
-    public Browse(Service<?, ?> service, String objectID, BrowseFlag flag, String filter, long firstResult,
+    protected Browse(Service<?, ?> service, String objectID, BrowseFlag flag, String filter, long firstResult,
             Long maxResults, SortCriterion... orderBy) {
 
         super(new ActionInvocation<>(service.getAction("Browse")));

--- a/bundles/org.jupnp.support/src/main/java/org/jupnp/support/contentdirectory/callback/GetSystemUpdateID.java
+++ b/bundles/org.jupnp.support/src/main/java/org/jupnp/support/contentdirectory/callback/GetSystemUpdateID.java
@@ -27,7 +27,7 @@ import org.jupnp.model.types.ErrorCode;
  */
 public abstract class GetSystemUpdateID extends ActionCallback {
 
-    public GetSystemUpdateID(Service<?, ?> service) {
+    protected GetSystemUpdateID(Service<?, ?> service) {
         super(new ActionInvocation<>(service.getAction("GetSystemUpdateID")));
     }
 

--- a/bundles/org.jupnp.support/src/main/java/org/jupnp/support/contentdirectory/callback/Search.java
+++ b/bundles/org.jupnp.support/src/main/java/org/jupnp/support/contentdirectory/callback/Search.java
@@ -60,14 +60,14 @@ public abstract class Search extends ActionCallback {
     /**
      * Search with first result 0 and {@link #getDefaultMaxResults()}, filters with {@link #CAPS_WILDCARD}.
      */
-    public Search(Service<?, ?> service, String containerId, String searchCriteria) {
+    protected Search(Service<?, ?> service, String containerId, String searchCriteria) {
         this(service, containerId, searchCriteria, CAPS_WILDCARD, 0, null);
     }
 
     /**
      * @param maxResults Can be <code>null</code>, then {@link #getDefaultMaxResults()} is used.
      */
-    public Search(Service<?, ?> service, String containerId, String searchCriteria, String filter, long firstResult,
+    protected Search(Service<?, ?> service, String containerId, String searchCriteria, String filter, long firstResult,
             Long maxResults, SortCriterion... orderBy) {
         super(new ActionInvocation<>(service.getAction("Search")));
 

--- a/bundles/org.jupnp.support/src/main/java/org/jupnp/support/igd/callback/GetExternalIP.java
+++ b/bundles/org.jupnp.support/src/main/java/org/jupnp/support/igd/callback/GetExternalIP.java
@@ -25,7 +25,7 @@ import org.jupnp.model.meta.Service;
  */
 public abstract class GetExternalIP extends ActionCallback {
 
-    public GetExternalIP(Service<?, ?> service) {
+    protected GetExternalIP(Service<?, ?> service) {
         super(new ActionInvocation<>(service.getAction("GetExternalIPAddress")));
     }
 

--- a/bundles/org.jupnp.support/src/main/java/org/jupnp/support/igd/callback/GetStatusInfo.java
+++ b/bundles/org.jupnp.support/src/main/java/org/jupnp/support/igd/callback/GetStatusInfo.java
@@ -29,7 +29,7 @@ import org.jupnp.support.model.Connection;
  */
 public abstract class GetStatusInfo extends ActionCallback {
 
-    public GetStatusInfo(Service<?, ?> service) {
+    protected GetStatusInfo(Service<?, ?> service) {
         super(new ActionInvocation<>(service.getAction("GetStatusInfo")));
     }
 

--- a/bundles/org.jupnp.support/src/main/java/org/jupnp/support/igd/callback/PortMappingAdd.java
+++ b/bundles/org.jupnp.support/src/main/java/org/jupnp/support/igd/callback/PortMappingAdd.java
@@ -29,7 +29,7 @@ public abstract class PortMappingAdd extends ActionCallback {
 
     protected final PortMapping portMapping;
 
-    public PortMappingAdd(Service<?, ?> service, PortMapping portMapping) {
+    protected PortMappingAdd(Service<?, ?> service, PortMapping portMapping) {
         this(service, null, portMapping);
     }
 

--- a/bundles/org.jupnp.support/src/main/java/org/jupnp/support/igd/callback/PortMappingDelete.java
+++ b/bundles/org.jupnp.support/src/main/java/org/jupnp/support/igd/callback/PortMappingDelete.java
@@ -29,7 +29,7 @@ public abstract class PortMappingDelete extends ActionCallback {
 
     protected final PortMapping portMapping;
 
-    public PortMappingDelete(Service<?, ?> service, PortMapping portMapping) {
+    protected PortMappingDelete(Service<?, ?> service, PortMapping portMapping) {
         this(service, null, portMapping);
     }
 

--- a/bundles/org.jupnp.support/src/main/java/org/jupnp/support/igd/callback/PortMappingEntryGet.java
+++ b/bundles/org.jupnp.support/src/main/java/org/jupnp/support/igd/callback/PortMappingEntryGet.java
@@ -31,7 +31,7 @@ import org.jupnp.support.model.PortMapping;
  */
 public abstract class PortMappingEntryGet extends ActionCallback {
 
-    public PortMappingEntryGet(Service<?, ?> service, long index) {
+    protected PortMappingEntryGet(Service<?, ?> service, long index) {
         this(service, null, index);
     }
 

--- a/bundles/org.jupnp.support/src/main/java/org/jupnp/support/lastchange/EventedValue.java
+++ b/bundles/org.jupnp.support/src/main/java/org/jupnp/support/lastchange/EventedValue.java
@@ -29,11 +29,11 @@ public abstract class EventedValue<V> {
 
     protected final V value;
 
-    public EventedValue(V value) {
+    protected EventedValue(V value) {
         this.value = value;
     }
 
-    public EventedValue(Map.Entry<String, String>[] attributes) {
+    protected EventedValue(Map.Entry<String, String>[] attributes) {
         try {
             this.value = valueOf(attributes);
         } catch (InvalidValueException ex) {

--- a/bundles/org.jupnp.support/src/main/java/org/jupnp/support/lastchange/EventedValueEnum.java
+++ b/bundles/org.jupnp.support/src/main/java/org/jupnp/support/lastchange/EventedValueEnum.java
@@ -25,11 +25,11 @@ import org.jupnp.model.types.Datatype;
  */
 public abstract class EventedValueEnum<E extends Enum<E>> extends EventedValue<E> {
 
-    public EventedValueEnum(E e) {
+    protected EventedValueEnum(E e) {
         super(e);
     }
 
-    public EventedValueEnum(Map.Entry<String, String>[] attributes) {
+    protected EventedValueEnum(Map.Entry<String, String>[] attributes) {
         super(attributes);
     }
 

--- a/bundles/org.jupnp.support/src/main/java/org/jupnp/support/lastchange/EventedValueEnumArray.java
+++ b/bundles/org.jupnp.support/src/main/java/org/jupnp/support/lastchange/EventedValueEnumArray.java
@@ -26,11 +26,11 @@ import org.jupnp.model.types.Datatype;
  */
 public abstract class EventedValueEnumArray<E extends Enum<E>> extends EventedValue<E[]> {
 
-    public EventedValueEnumArray(E[] e) {
+    protected EventedValueEnumArray(E[] e) {
         super(e);
     }
 
-    public EventedValueEnumArray(Map.Entry<String, String>[] attributes) {
+    protected EventedValueEnumArray(Map.Entry<String, String>[] attributes) {
         super(attributes);
     }
 

--- a/bundles/org.jupnp.support/src/main/java/org/jupnp/support/messagebox/AddMessage.java
+++ b/bundles/org.jupnp.support/src/main/java/org/jupnp/support/messagebox/AddMessage.java
@@ -29,7 +29,7 @@ public abstract class AddMessage extends ActionCallback {
 
     protected final MimeType mimeType = MimeType.valueOf("text/xml;charset=\"utf-8\"");
 
-    public AddMessage(Service<?, ?> service, Message message) {
+    protected AddMessage(Service<?, ?> service, Message message) {
         super(new ActionInvocation<>(service.getAction("AddMessage")));
 
         getActionInvocation().setInput("MessageID", Integer.toString(message.getId()));

--- a/bundles/org.jupnp.support/src/main/java/org/jupnp/support/messagebox/RemoveMessage.java
+++ b/bundles/org.jupnp.support/src/main/java/org/jupnp/support/messagebox/RemoveMessage.java
@@ -28,11 +28,11 @@ import org.jupnp.support.messagebox.model.Message;
  */
 public abstract class RemoveMessage extends ActionCallback {
 
-    public RemoveMessage(Service<?, ?> service, Message message) {
+    protected RemoveMessage(Service<?, ?> service, Message message) {
         this(service, message.getId());
     }
 
-    public RemoveMessage(Service<?, ?> service, int id) {
+    protected RemoveMessage(Service<?, ?> service, int id) {
         super(new ActionInvocation<>(service.getAction("RemoveMessage")));
         getActionInvocation().setInput("MessageID", id);
     }

--- a/bundles/org.jupnp.support/src/main/java/org/jupnp/support/messagebox/model/Message.java
+++ b/bundles/org.jupnp.support/src/main/java/org/jupnp/support/messagebox/model/Message.java
@@ -60,11 +60,11 @@ public abstract class Message implements ElementAppender {
     private final Category category;
     private DisplayType displayType;
 
-    public Message(Category category, DisplayType displayType) {
+    protected Message(Category category, DisplayType displayType) {
         this(0, category, displayType);
     }
 
-    public Message(int id, Category category, DisplayType displayType) {
+    protected Message(int id, Category category, DisplayType displayType) {
         if (id == 0) {
             id = randomGenerator.nextInt(Integer.MAX_VALUE);
         }

--- a/bundles/org.jupnp.support/src/main/java/org/jupnp/support/renderingcontrol/callback/GetMute.java
+++ b/bundles/org.jupnp.support/src/main/java/org/jupnp/support/renderingcontrol/callback/GetMute.java
@@ -27,11 +27,11 @@ import org.jupnp.support.model.Channel;
  */
 public abstract class GetMute extends ActionCallback {
 
-    public GetMute(Service<?, ?> service) {
+    protected GetMute(Service<?, ?> service) {
         this(new UnsignedIntegerFourBytes(0), service);
     }
 
-    public GetMute(UnsignedIntegerFourBytes instanceId, Service<?, ?> service) {
+    protected GetMute(UnsignedIntegerFourBytes instanceId, Service<?, ?> service) {
         super(new ActionInvocation<>(service.getAction("GetMute")));
         getActionInvocation().setInput("InstanceID", instanceId);
         getActionInvocation().setInput("Channel", Channel.Master.toString());

--- a/bundles/org.jupnp.support/src/main/java/org/jupnp/support/renderingcontrol/callback/GetVolume.java
+++ b/bundles/org.jupnp.support/src/main/java/org/jupnp/support/renderingcontrol/callback/GetVolume.java
@@ -29,11 +29,11 @@ import org.jupnp.support.model.Channel;
  */
 public abstract class GetVolume extends ActionCallback {
 
-    public GetVolume(Service<?, ?> service) {
+    protected GetVolume(Service<?, ?> service) {
         this(new UnsignedIntegerFourBytes(0), service);
     }
 
-    public GetVolume(UnsignedIntegerFourBytes instanceId, Service<?, ?> service) {
+    protected GetVolume(UnsignedIntegerFourBytes instanceId, Service<?, ?> service) {
         super(new ActionInvocation<>(service.getAction("GetVolume")));
         getActionInvocation().setInput("InstanceID", instanceId);
         getActionInvocation().setInput("Channel", Channel.Master.toString());

--- a/bundles/org.jupnp.support/src/main/java/org/jupnp/support/renderingcontrol/callback/SetMute.java
+++ b/bundles/org.jupnp.support/src/main/java/org/jupnp/support/renderingcontrol/callback/SetMute.java
@@ -31,11 +31,11 @@ public abstract class SetMute extends ActionCallback {
 
     private final Logger logger = LoggerFactory.getLogger(SetMute.class.getName());
 
-    public SetMute(Service<?, ?> service, boolean desiredMute) {
+    protected SetMute(Service<?, ?> service, boolean desiredMute) {
         this(new UnsignedIntegerFourBytes(0), service, desiredMute);
     }
 
-    public SetMute(UnsignedIntegerFourBytes instanceId, Service<?, ?> service, boolean desiredMute) {
+    protected SetMute(UnsignedIntegerFourBytes instanceId, Service<?, ?> service, boolean desiredMute) {
         super(new ActionInvocation<>(service.getAction("SetMute")));
         getActionInvocation().setInput("InstanceID", instanceId);
         getActionInvocation().setInput("Channel", Channel.Master.toString());

--- a/bundles/org.jupnp.support/src/main/java/org/jupnp/support/renderingcontrol/callback/SetVolume.java
+++ b/bundles/org.jupnp.support/src/main/java/org/jupnp/support/renderingcontrol/callback/SetVolume.java
@@ -32,11 +32,11 @@ public abstract class SetVolume extends ActionCallback {
 
     private final Logger logger = LoggerFactory.getLogger(SetVolume.class);
 
-    public SetVolume(Service<?, ?> service, long newVolume) {
+    protected SetVolume(Service<?, ?> service, long newVolume) {
         this(new UnsignedIntegerFourBytes(0), service, newVolume);
     }
 
-    public SetVolume(UnsignedIntegerFourBytes instanceId, Service<?, ?> service, long newVolume) {
+    protected SetVolume(UnsignedIntegerFourBytes instanceId, Service<?, ?> service, long newVolume) {
         super(new ActionInvocation<>(service.getAction("SetVolume")));
         getActionInvocation().setInput("InstanceID", instanceId);
         getActionInvocation().setInput("Channel", Channel.Master.toString());

--- a/bundles/org.jupnp/src/main/java/org/jupnp/model/gena/GENASubscription.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/model/gena/GENASubscription.java
@@ -49,7 +49,7 @@ public abstract class GENASubscription<S extends Service> {
         this.service = service;
     }
 
-    public GENASubscription(S service, int requestedDurationSeconds) {
+    protected GENASubscription(S service, int requestedDurationSeconds) {
         this(service);
         this.requestedDurationSeconds = requestedDurationSeconds;
     }

--- a/bundles/org.jupnp/src/main/java/org/jupnp/model/gena/LocalGENASubscription.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/model/gena/LocalGENASubscription.java
@@ -68,7 +68,7 @@ public abstract class LocalGENASubscription extends GENASubscription<LocalServic
         this.callbackURLs = callbackURLs;
     }
 
-    public LocalGENASubscription(LocalService service, Integer requestedDurationSeconds, List<URL> callbackURLs)
+    protected LocalGENASubscription(LocalService service, Integer requestedDurationSeconds, List<URL> callbackURLs)
             throws Exception {
         super(service);
 

--- a/bundles/org.jupnp/src/main/java/org/jupnp/model/meta/Device.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/model/meta/Device.java
@@ -58,22 +58,22 @@ public abstract class Device<DI extends DeviceIdentity, D extends Device, S exte
     // Package mutable state
     private D parentDevice;
 
-    public Device(DI identity) throws ValidationException {
+    protected Device(DI identity) throws ValidationException {
         this(identity, null, null, null, null, null);
     }
 
-    public Device(DI identity, DeviceType type, DeviceDetails details, Icon[] icons, S[] services)
+    protected Device(DI identity, DeviceType type, DeviceDetails details, Icon[] icons, S[] services)
             throws ValidationException {
         this(identity, null, type, details, icons, services, null);
     }
 
-    public Device(DI identity, DeviceType type, DeviceDetails details, Icon[] icons, S[] services, D[] embeddedDevices)
-            throws ValidationException {
+    protected Device(DI identity, DeviceType type, DeviceDetails details, Icon[] icons, S[] services,
+            D[] embeddedDevices) throws ValidationException {
         this(identity, null, type, details, icons, services, embeddedDevices);
     }
 
-    public Device(DI identity, UDAVersion version, DeviceType type, DeviceDetails details, Icon[] icons, S[] services,
-            D[] embeddedDevices) throws ValidationException {
+    protected Device(DI identity, UDAVersion version, DeviceType type, DeviceDetails details, Icon[] icons,
+            S[] services, D[] embeddedDevices) throws ValidationException {
 
         this.identity = identity;
         this.version = version == null ? new UDAVersion() : version;

--- a/bundles/org.jupnp/src/main/java/org/jupnp/model/meta/Service.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/model/meta/Service.java
@@ -47,12 +47,12 @@ public abstract class Service<D extends Device, S extends Service> {
     // Package mutable state
     private D device;
 
-    public Service(ServiceType serviceType, ServiceId serviceId) throws ValidationException {
+    protected Service(ServiceType serviceType, ServiceId serviceId) throws ValidationException {
         this(serviceType, serviceId, null, null);
     }
 
-    public Service(ServiceType serviceType, ServiceId serviceId, Action<S>[] actions, StateVariable<S>[] stateVariables)
-            throws ValidationException {
+    protected Service(ServiceType serviceType, ServiceId serviceId, Action<S>[] actions,
+            StateVariable<S>[] stateVariables) throws ValidationException {
 
         this.serviceType = serviceType;
         this.serviceId = serviceId;

--- a/bundles/org.jupnp/src/main/java/org/jupnp/model/types/UnsignedVariableInteger.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/model/types/UnsignedVariableInteger.java
@@ -47,11 +47,11 @@ public abstract class UnsignedVariableInteger {
     protected UnsignedVariableInteger() {
     }
 
-    public UnsignedVariableInteger(long value) throws NumberFormatException {
+    protected UnsignedVariableInteger(long value) throws NumberFormatException {
         setValue(value);
     }
 
-    public UnsignedVariableInteger(String s) throws NumberFormatException {
+    protected UnsignedVariableInteger(String s) throws NumberFormatException {
         if (s.startsWith("-")) {
             // Don't throw exception, just cut it!
             // TODO: UPNP VIOLATION: Twonky Player returns "-1" as the track number

--- a/bundles/org.jupnp/src/main/java/org/jupnp/model/types/csv/CSV.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/model/types/csv/CSV.java
@@ -43,11 +43,11 @@ public abstract class CSV<T> extends ArrayList<T> {
 
     protected final Datatype.Builtin datatype;
 
-    public CSV() {
+    protected CSV() {
         datatype = getBuiltinDatatype();
     }
 
-    public CSV(String s) throws InvalidValueException {
+    protected CSV(String s) throws InvalidValueException {
         datatype = getBuiltinDatatype();
         addAll(parseString(s));
     }

--- a/bundles/org.jupnp/src/main/java/org/jupnp/protocol/async/SendingNotification.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/protocol/async/SendingNotification.java
@@ -49,7 +49,7 @@ public abstract class SendingNotification extends SendingAsync {
 
     private LocalDevice device;
 
-    public SendingNotification(UpnpService upnpService, LocalDevice device) {
+    protected SendingNotification(UpnpService upnpService, LocalDevice device) {
         super(upnpService);
         this.device = device;
     }

--- a/bundles/org.jupnp/src/main/java/org/jupnp/transport/impl/HttpExchangeUpnpStream.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/transport/impl/HttpExchangeUpnpStream.java
@@ -50,7 +50,7 @@ public abstract class HttpExchangeUpnpStream extends UpnpStream {
 
     private HttpExchange httpExchange;
 
-    public HttpExchangeUpnpStream(ProtocolFactory protocolFactory, HttpExchange httpExchange) {
+    protected HttpExchangeUpnpStream(ProtocolFactory protocolFactory, HttpExchange httpExchange) {
         super(protocolFactory);
         this.httpExchange = httpExchange;
     }

--- a/bundles/org.jupnp/src/main/java/org/jupnp/transport/impl/PooledXmlProcessor.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/transport/impl/PooledXmlProcessor.java
@@ -48,11 +48,11 @@ public abstract class PooledXmlProcessor {
 
     private final transient Logger logger = LoggerFactory.getLogger(PooledXmlProcessor.class);
 
-    public PooledXmlProcessor() {
+    protected PooledXmlProcessor() {
         this(20);
     }
 
-    public PooledXmlProcessor(int basePoolSize) {
+    protected PooledXmlProcessor(int basePoolSize) {
         documentBuilderFactory = DocumentBuilderFactory.newInstance();
         documentBuilderFactory.setNamespaceAware(true);
         builderPool = new ConcurrentLinkedQueue<>();

--- a/bundles/org.jupnp/src/main/java/org/jupnp/transport/impl/ServletUpnpStream.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/transport/impl/ServletUpnpStream.java
@@ -50,7 +50,7 @@ public abstract class ServletUpnpStream extends UpnpStream {
 
     protected final Logger log = LoggerFactory.getLogger(ServletUpnpStream.class);
 
-    public ServletUpnpStream(ProtocolFactory protocolFactory) {
+    protected ServletUpnpStream(ProtocolFactory protocolFactory) {
         super(protocolFactory);
     }
 

--- a/bundles/org.jupnp/src/main/java/org/jupnp/transport/impl/async/AsyncServletUpnpStream.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/transport/impl/async/AsyncServletUpnpStream.java
@@ -45,7 +45,7 @@ public abstract class AsyncServletUpnpStream extends ServletUpnpStream implement
     protected final AsyncContext asyncContext;
     protected final HttpServletRequest request;
 
-    public AsyncServletUpnpStream(ProtocolFactory protocolFactory, AsyncContext asyncContext,
+    protected AsyncServletUpnpStream(ProtocolFactory protocolFactory, AsyncContext asyncContext,
             HttpServletRequest request) {
         super(protocolFactory);
         this.asyncContext = asyncContext;

--- a/bundles/org.jupnp/src/main/java/org/jupnp/transport/impl/blocking/BlockingServletUpnpStream.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/transport/impl/blocking/BlockingServletUpnpStream.java
@@ -37,7 +37,7 @@ public abstract class BlockingServletUpnpStream extends ServletUpnpStream {
 
     protected StreamResponseMessage responseMessage;
 
-    public BlockingServletUpnpStream(ProtocolFactory protocolFactory, FauxAsyncContext asyncContext) {
+    protected BlockingServletUpnpStream(ProtocolFactory protocolFactory, FauxAsyncContext asyncContext) {
         super(protocolFactory);
         this.asyncContext = asyncContext;
     }

--- a/bundles/org.jupnp/src/main/java/org/jupnp/util/Iterators.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/util/Iterators.java
@@ -89,7 +89,7 @@ public class Iterators {
         int nextIndex = 0;
         boolean removedCurrent = false;
 
-        public Synchronized(Collection<E> collection) {
+        protected Synchronized(Collection<E> collection) {
             this.wrapped = new CopyOnWriteArrayList<>(collection).iterator();
         }
 

--- a/bundles/org.jupnp/src/main/java/org/jupnp/xml/DOM.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/xml/DOM.java
@@ -36,7 +36,7 @@ public abstract class DOM {
 
     private Document dom;
 
-    public DOM(Document dom) {
+    protected DOM(Document dom) {
         this.dom = dom;
     }
 

--- a/bundles/org.jupnp/src/main/java/org/jupnp/xml/DOMElement.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/xml/DOMElement.java
@@ -48,7 +48,7 @@ public abstract class DOMElement<CHILD extends DOMElement, PARENT extends DOMEle
     private final XPath xpath;
     private Element element;
 
-    public DOMElement(XPath xpath, Element element) {
+    protected DOMElement(XPath xpath, Element element) {
         this.xpath = xpath;
         this.element = element;
         this.PARENT_BUILDER = createParentBuilder(this);

--- a/bundles/org.jupnp/src/main/java/org/jupnp/xml/DOMParser.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/xml/DOMParser.java
@@ -82,11 +82,11 @@ public abstract class DOMParser<D extends DOM> implements ErrorHandler, EntityRe
     protected Source[] schemaSources;
     protected Schema schema;
 
-    public DOMParser() {
+    protected DOMParser() {
         this(null);
     }
 
-    public DOMParser(Source[] schemaSources) {
+    protected DOMParser(Source[] schemaSources) {
         this.schemaSources = schemaSources;
     }
 

--- a/bundles/org.jupnp/src/test/java/org/jupnp/service/QueueingThreadPoolExecutorTest.java
+++ b/bundles/org.jupnp/src/test/java/org/jupnp/service/QueueingThreadPoolExecutorTest.java
@@ -772,7 +772,7 @@ class QueueingThreadPoolExecutorTest {
 
         protected Logger logger = LoggerFactory.getLogger(this.getClass());
 
-        public AbstractRunnable() {
+        protected AbstractRunnable() {
             uniqueId = lastUniqueId.incrementAndGet();
         }
 

--- a/bundles/org.jupnp/src/test/java/org/jupnp/transport/StreamServerClientTest.java
+++ b/bundles/org.jupnp/src/test/java/org/jupnp/transport/StreamServerClientTest.java
@@ -252,7 +252,7 @@ public abstract class StreamServerClientTest {
     public abstract static class TestProtocol extends ReceivingSync<StreamRequestMessage, StreamResponseMessage> {
         public volatile boolean isComplete;
 
-        public TestProtocol(StreamRequestMessage inputMessage) {
+        protected TestProtocol(StreamRequestMessage inputMessage) {
             super(null, inputMessage);
         }
     }


### PR DESCRIPTION
Abstract classes should not have public constructors.
Constructors of abstract classes can only be called in constructors of their subclasses.
So there is no point in making them public.
The protected modifier should be enough.