### PR TITLE
Remove www from URLs in POM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 
   <organization>
     <name>jUPnP.org</name>
-    <url>https://www.jupnp.org</url>
+    <url>https://jupnp.org</url>
   </organization>
 
   <licenses>
@@ -31,7 +31,7 @@
       <name>Kai Kreuzer</name>
       <email>kai@openhab.org</email>
       <organization>jUPnP.org</organization>
-      <organizationUrl>https://www.jupnp.org</organizationUrl>
+      <organizationUrl>https://jupnp.org</organizationUrl>
     </developer>
   </developers>
 


### PR DESCRIPTION
Consistenly use the same URL without `www` in the POM.