### PR TITLE
Upgrade GHA dependencies

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -28,16 +28,16 @@ jobs:
 
       - name: Checkout
         if: github.head_ref == ''
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Checkout merge
         if: github.head_ref != ''
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: refs/pull/${{github.event.pull_request.number}}/merge
 
       - name: Set up Cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.m2/repository
@@ -46,13 +46,13 @@ jobs:
             ${{ runner.os }}-maven-
 
       - name: Set up Java ${{ matrix.java }}
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}
 
       - name: Set up Maven ${{ matrix.maven }}
-        uses: stCarolas/setup-maven@v4.5
+        uses: stCarolas/setup-maven@v5
         with:
           maven-version: ${{ matrix.maven }}
 


### PR DESCRIPTION
This fixes the following deprecation warning:

> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20