### PR TITLE
Add new optional parameter "interfaces" in OSGi configuration

### DIFF
--- a/bundles/org.jupnp/src/main/java/org/jupnp/OSGiUpnpServiceConfiguration.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/OSGiUpnpServiceConfiguration.java
@@ -87,6 +87,7 @@ import org.slf4j.LoggerFactory;
  * @author Kai Kreuzer - introduced bounded thread pool and http service streaming server
  * @author Victor Toni - consolidated transport abstraction into one interface
  * @author Wouter Born - conditionally enable component based on autoEnable configuration value
+ * @author Laurent Garnier - added parameter "interfaces" to set a list of network interfaces to consider
  */
 @Component(configurationPid = "org.jupnp", configurationPolicy = ConfigurationPolicy.REQUIRE, enabled = false)
 public class OSGiUpnpServiceConfiguration implements UpnpServiceConfiguration {
@@ -99,6 +100,7 @@ public class OSGiUpnpServiceConfiguration implements UpnpServiceConfiguration {
     protected int threadPoolSize = 20;
     protected int asyncThreadPoolSize = 20;
     protected int remoteThreadPoolSize = 40;
+    protected String interfaces;
     protected int multicastResponsePort;
     protected int httpProxyPort = -1;
     protected int streamListenPort = 8080;
@@ -389,7 +391,7 @@ public class OSGiUpnpServiceConfiguration implements UpnpServiceConfiguration {
     }
 
     protected NetworkAddressFactory createNetworkAddressFactory(int streamListenPort, int multicastResponsePort) {
-        return new NetworkAddressFactoryImpl(streamListenPort, multicastResponsePort);
+        return new NetworkAddressFactoryImpl(streamListenPort, multicastResponsePort, interfaces);
     }
 
     protected DatagramProcessor createDatagramProcessor() {
@@ -527,6 +529,12 @@ public class OSGiUpnpServiceConfiguration implements UpnpServiceConfiguration {
                         streamListenPort);
             }
         }
+
+        prop = properties.get("interfaces");
+        if (prop instanceof String) {
+            interfaces = (String) prop;
+        }
+        logger.info("OSGiUpnpServiceConfiguration interfaces = {}", interfaces);
 
         prop = properties.get("callbackURI");
         if (prop instanceof String) {

--- a/bundles/org.jupnp/src/main/java/org/jupnp/transport/impl/NetworkAddressFactoryImpl.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/transport/impl/NetworkAddressFactoryImpl.java
@@ -48,6 +48,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Christian Bauer
  * @author Kai Kreuzer - added multicast response port
+ * @author Laurent Garnier - added new parameter to provide a list of network interfaces to consider
  */
 public class NetworkAddressFactoryImpl implements NetworkAddressFactory {
 
@@ -76,7 +77,13 @@ public class NetworkAddressFactoryImpl implements NetworkAddressFactory {
     }
 
     public NetworkAddressFactoryImpl(int streamListenPort, int multicastResponsePort) throws InitializationException {
-        String useInterfacesString = System.getProperty(SYSTEM_PROPERTY_NET_IFACES);
+        this(streamListenPort, multicastResponsePort, null);
+    }
+
+    public NetworkAddressFactoryImpl(int streamListenPort, int multicastResponsePort, String interfaces)
+            throws InitializationException {
+        String useInterfacesString = interfaces != null && !interfaces.isBlank() ? interfaces
+                : System.getProperty(SYSTEM_PROPERTY_NET_IFACES);
         if (useInterfacesString != null) {
             String[] userInterfacesStrings = useInterfacesString.split(",");
             useInterfaces.addAll(Arrays.asList(userInterfacesStrings));
@@ -408,8 +415,8 @@ public class NetworkAddressFactoryImpl implements NetworkAddressFactory {
         }
 
         if (!useInterfaces.isEmpty() && !useInterfaces.contains(iface.getName())) {
-            logger.trace("Skipping unwanted network interface (-D {} ): {}", SYSTEM_PROPERTY_NET_IFACES,
-                    iface.getName());
+            logger.trace("Skipping unwanted network interface (OSGi parameter 'interfaces' or -D {}): {}",
+                    SYSTEM_PROPERTY_NET_IFACES, iface.getName());
             return false;
         }
 


### PR DESCRIPTION
This parameter is optional. It is a comma-separated list of network interface names.
It allows restricting the network interfaces to be considered by the library.

Signed-off-by: Laurent Garnier <lg.hc@free.fr>