### PR TITLE
Parse fractional track numbers

### DIFF
--- a/bundles/org.jupnp.support/src/main/java/org/jupnp/support/contentdirectory/DIDLParser.java
+++ b/bundles/org.jupnp.support/src/main/java/org/jupnp/support/contentdirectory/DIDLParser.java
@@ -763,7 +763,7 @@ public class DIDLParser extends SAXParser {
                             new DIDLObject.Property.UPNP.DVD_REGION_CODE(Integer.valueOf(getCharacters())));
                 } else if ("originalTrackNumber".equals(localName)) {
                     getInstance().addProperty(
-                            new DIDLObject.Property.UPNP.ORIGINAL_TRACK_NUMBER(Integer.valueOf(getCharacters())));
+                            new DIDLObject.Property.UPNP.ORIGINAL_TRACK_NUMBER(Integer.valueOf(getCharacters().split("/")[0])));
                 } else if ("userAnnotation".equals(localName)) {
                     getInstance().addProperty(new DIDLObject.Property.UPNP.USER_ANNOTATION(getCharacters()));
                 }


### PR DESCRIPTION
Allow parsing of `{trackNum}/{totalTrack}` formats.

Often, when parsing track numbers, the format could be either `{trackNum}` ex: "3", or it could be `{trackNum}/{totalTracks}` ex. "3/18". In the second case, the parser fails and cannot read the response, this makes sure to only grab the track number, and not attempt to parse the entire string.