### PR TITLE
Added compatibility methods for Android

### DIFF
--- a/bundles/org.jupnp/src/main/java/org/jupnp/model/meta/Icon.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/model/meta/Icon.java
@@ -15,6 +15,7 @@
  */
 package org.jupnp.model.meta;
 
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -90,7 +91,7 @@ public class Icon implements Validatable {
      */
     public Icon(String mimeType, int width, int height, int depth, String uniqueName, InputStream is)
             throws IOException {
-        this(mimeType, width, height, depth, uniqueName, is.readAllBytes());
+        this(mimeType, width, height, depth, uniqueName, convert(is));
     }
 
     /**
@@ -105,7 +106,7 @@ public class Icon implements Validatable {
 
     /**
      * Use this constructor if your local icon is binary data encoded with <em>BinHex</em>.
-     * 
+     *
      * @param uniqueName Must be a valid URI path segment and unique within the scope of a device.
      * @param binHexEncoded The icon bytes encoded as BinHex.
      */
@@ -156,6 +157,29 @@ public class Icon implements Validatable {
             throw new IllegalStateException("Final value has been set already, model is immutable");
         }
         this.device = device;
+    }
+
+    /**
+     * Converts the given InputStream into a byte array. This method should be replaced by
+     * java.io.InputStream#readAllBytes when Android 13 (API Level 33) is more widely used.
+     *
+     * @param inputStream the InputStream to be converted
+     * @return a byte array containing the data from the InputStream
+     * @throws IOException if an I/O error occurs
+     */
+    public static byte[] convert(InputStream inputStream) throws IOException {
+        ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+        int nRead;
+        byte[] data = new byte[1024];
+
+        // Read data from InputStream in chunks of 1024 bytes
+        while ((nRead = inputStream.read(data, 0, data.length)) != -1) {
+            // Write the read data into ByteArrayOutputStream
+            buffer.write(data, 0, nRead);
+        }
+
+        // Return the complete byte array
+        return buffer.toByteArray();
     }
 
     @Override

--- a/bundles/org.jupnp/src/main/java/org/jupnp/util/Reflections.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/util/Reflections.java
@@ -59,7 +59,7 @@ public class Reflections {
     // ####################
 
     public static Object get(Field field, Object target) throws Exception {
-        boolean accessible = field.canAccess(target);
+        boolean accessible = canAccessField(field);
         try {
             field.setAccessible(true);
             return field.get(target);
@@ -88,7 +88,7 @@ public class Reflections {
     // ####################
 
     public static void set(Field field, Object target, Object value) throws Exception {
-        boolean accessible = field.canAccess(target);
+        boolean accessible = canAccessField(field);
         try {
             field.setAccessible(true);
             field.set(target, value);
@@ -266,7 +266,7 @@ public class Reflections {
     }
 
     public static Object getAndWrap(Field field, Object target) {
-        boolean accessible = field.canAccess(target);
+        boolean accessible = canAccessField(field);
         try {
             field.setAccessible(true);
             return get(field, target);
@@ -282,7 +282,7 @@ public class Reflections {
     }
 
     public static void setAndWrap(Field field, Object target, Object value) {
-        boolean accessible = field.canAccess(target);
+        boolean accessible = canAccessField(field);
         try {
             field.setAccessible(true);
             set(field, target, value);
@@ -443,5 +443,29 @@ public class Reflections {
         char[] chars = name.toCharArray();
         chars[0] = Character.toLowerCase(chars[0]);
         return new String(chars);
+    }
+
+    /**
+     * Checks if the specified field can be accessed. This method should be replaced by
+     * java.lang.reflect.Field#canAccess when it becomes available in Android.
+     *
+     * @param field the field to check access for
+     * @return true if the field can be accessed, false otherwise
+     */
+    public static boolean canAccessField(Field field) {
+        // Save the original accessibility state of the field
+        boolean isAccessible = field.isAccessible();
+        try {
+            // Try to make the field accessible
+            field.setAccessible(true);
+            // If no exception is thrown, access is possible
+            return true;
+        } catch (SecurityException e) {
+            // Access is not possible
+            return false;
+        } finally {
+            // Restore the original accessibility state of the field
+            field.setAccessible(isAccessible);
+        }
     }
 }


### PR DESCRIPTION
- Implemented canAccessField to check field accessibility, to be replaced by java.lang.reflect.Field#canAccess when available in Android.
- Implemented convert method to read all bytes from an InputStream, to be replaced by java.io.InputStream#readAllBytes when Android 13 (API Level 33) is more widely used.