### PR TITLE
Fix server port is always 0 when user unspecify the port

### DIFF
--- a/bundles/org.jupnp/src/main/java/org/jupnp/transport/impl/jetty/JettyServletContainer.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/transport/impl/jetty/JettyServletContainer.java
@@ -72,7 +72,7 @@ public class JettyServletContainer implements ServletContainerAdapter {
         // Only add if open() succeeded
         server.addConnector(connector);
 
-        // stats the connector if the server is started (server starts all connectors when started)
+        // starts the connector if the server is started (server starts all connectors when started)
         if (server.isStarted()) {
             try {
                 connector.start();

--- a/bundles/org.jupnp/src/main/java/org/jupnp/transport/impl/jetty/JettyServletContainer.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/transport/impl/jetty/JettyServletContainer.java
@@ -77,7 +77,7 @@ public class JettyServletContainer implements ServletContainerAdapter {
             try {
                 connector.start();
             } catch (Exception e) {
-                logger.warn("Couldn't start connector: {}", connector , e);
+                logger.warn("Couldn't start connector: {}", connector, e);
                 throw new RuntimeException("Couldn't start connector", e);
             }
         }

--- a/bundles/org.jupnp/src/main/java/org/jupnp/transport/impl/jetty/JettyServletContainer.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/transport/impl/jetty/JettyServletContainer.java
@@ -76,9 +76,9 @@ public class JettyServletContainer implements ServletContainerAdapter {
         if (server.isStarted()) {
             try {
                 connector.start();
-            } catch (Exception ex) {
-                logger.warn("Couldn't start connector: " + connector + " " + ex);
-                throw new RuntimeException(ex);
+            } catch (Exception e) {
+                logger.warn("Couldn't start connector: {}", connector , e);
+                throw new RuntimeException("Couldn't start connector", e);
             }
         }
         return connector.getLocalPort();

--- a/bundles/org.jupnp/src/main/java/org/jupnp/transport/impl/jetty/JettyServletContainer.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/transport/impl/jetty/JettyServletContainer.java
@@ -65,8 +65,23 @@ public class JettyServletContainer implements ServletContainerAdapter {
         ServerConnector connector = new ServerConnector(server);
         connector.setHost(host);
         connector.setPort(port);
+
+        // Open immediately so we can get the assigned local port
+        connector.open();
+
+        // Only add if open() succeeded
         server.addConnector(connector);
-        return port;
+
+        // stats the connector if the server is started (server starts all connectors when started)
+        if (server.isStarted()) {
+            try {
+                connector.start();
+            } catch (Exception ex) {
+                logger.warn("Couldn't start connector: " + connector + " " + ex);
+                throw new RuntimeException(ex);
+            }
+        }
+        return connector.getLocalPort();
     }
 
     @Override


### PR DESCRIPTION
When user not specify the port or keep the port to 0, the server port is always 0, and the callback register to remote server has a 0 port, and register will not receive the remote server message.

Open connector immediately, so we can get the assigned local port.

See [JettyServletContainer.addConnector](https://github.com/4thline/cling/blob/0ca10d5e73bdc8062eeffad57d67dd8ee260379c/core/src/main/java/org/fourthline/cling/transport/impl/jetty/JettyServletContainer.java#L75).