### PR TITLE
Add compatible method readAllbytes for Android

### DIFF
--- a/bundles/org.jupnp/src/main/java/org/jupnp/http/HttpFetch.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/http/HttpFetch.java
@@ -35,7 +35,7 @@ public class HttpFetch {
     public static Representation<byte[]> fetchBinary(URL url, int connectTimeoutMillis, int readTimeoutMillis)
             throws IOException {
         return fetch(url, connectTimeoutMillis, readTimeoutMillis,
-                (urlConnection, is) -> new Representation<>(urlConnection, is.readAllBytes()));
+                (urlConnection, is) -> new Representation<>(urlConnection, IO.readAllBytes(is)));
     }
 
     public static Representation<String> fetchString(URL url, int connectTimeoutMillis, int readTimeoutMillis)

--- a/bundles/org.jupnp/src/main/java/org/jupnp/model/meta/Icon.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/model/meta/Icon.java
@@ -15,7 +15,6 @@
  */
 package org.jupnp.model.meta;
 
-import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -32,6 +31,7 @@ import org.jupnp.model.types.BinHexDatatype;
 import org.jupnp.util.MimeType;
 import org.jupnp.util.SpecificationViolationReporter;
 import org.jupnp.util.URIUtil;
+import org.jupnp.util.io.IO;
 
 /**
  * The metadata of a device icon, might include the actual image data of a local icon.
@@ -91,7 +91,7 @@ public class Icon implements Validatable {
      */
     public Icon(String mimeType, int width, int height, int depth, String uniqueName, InputStream is)
             throws IOException {
-        this(mimeType, width, height, depth, uniqueName, convert(is));
+        this(mimeType, width, height, depth, uniqueName, IO.readAllBytes(is));
     }
 
     /**
@@ -157,29 +157,6 @@ public class Icon implements Validatable {
             throw new IllegalStateException("Final value has been set already, model is immutable");
         }
         this.device = device;
-    }
-
-    /**
-     * Converts the given InputStream into a byte array. This method should be replaced by
-     * java.io.InputStream#readAllBytes when Android 13 (API Level 33) is more widely used.
-     *
-     * @param inputStream the InputStream to be converted
-     * @return a byte array containing the data from the InputStream
-     * @throws IOException if an I/O error occurs
-     */
-    public static byte[] convert(InputStream inputStream) throws IOException {
-        ByteArrayOutputStream buffer = new ByteArrayOutputStream();
-        int nRead;
-        byte[] data = new byte[1024];
-
-        // Read data from InputStream in chunks of 1024 bytes
-        while ((nRead = inputStream.read(data, 0, data.length)) != -1) {
-            // Write the read data into ByteArrayOutputStream
-            buffer.write(data, 0, nRead);
-        }
-
-        // Return the complete byte array
-        return buffer.toByteArray();
     }
 
     @Override

--- a/bundles/org.jupnp/src/main/java/org/jupnp/transport/impl/HttpExchangeUpnpStream.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/transport/impl/HttpExchangeUpnpStream.java
@@ -29,6 +29,7 @@ import org.jupnp.model.message.UpnpMessage;
 import org.jupnp.model.message.UpnpRequest;
 import org.jupnp.protocol.ProtocolFactory;
 import org.jupnp.transport.spi.UpnpStream;
+import org.jupnp.util.io.IO;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -91,7 +92,7 @@ public abstract class HttpExchangeUpnpStream extends UpnpStream {
             // Body
             byte[] bodyBytes;
             try (InputStream is = getHttpExchange().getRequestBody()) {
-                bodyBytes = is.readAllBytes();
+                bodyBytes = IO.readAllBytes(is);
             }
 
             logger.trace("Reading request body bytes: {}", bodyBytes.length);

--- a/bundles/org.jupnp/src/main/java/org/jupnp/transport/impl/ServletUpnpStream.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/transport/impl/ServletUpnpStream.java
@@ -34,6 +34,7 @@ import org.jupnp.model.message.UpnpMessage;
 import org.jupnp.model.message.UpnpRequest;
 import org.jupnp.protocol.ProtocolFactory;
 import org.jupnp.transport.spi.UpnpStream;
+import org.jupnp.util.io.IO;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -129,7 +130,7 @@ public abstract class ServletUpnpStream extends UpnpStream {
             if (UpnpRequest.Method.GET.getHttpName().equals(requestMethod)) {
                 bodyBytes = new byte[] {};
             } else {
-                bodyBytes = is.readAllBytes();
+                bodyBytes = IO.readAllBytes(is);
             }
         }
         logger.trace("Reading request body bytes: {}", bodyBytes.length);

--- a/bundles/org.jupnp/src/main/java/org/jupnp/util/io/IO.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/util/io/IO.java
@@ -16,6 +16,7 @@
 package org.jupnp.util.io;
 
 import java.io.BufferedReader;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -39,5 +40,28 @@ public class IO {
         }
 
         return input.length() > 0 ? input.toString() : "";
+    }
+
+    /**
+     * Read the given InputStream into a byte array. This method should be replaced by
+     * java.io.InputStream#readAllBytes when Android 13 (API Level 33) is more widely used.
+     *
+     * @param inputStream the InputStream to be read
+     * @return a byte array containing the data from the InputStream
+     * @throws IOException if an I/O error occurs
+     */
+    public static byte[] readAllBytes(InputStream inputStream) throws IOException {
+        ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+        int nRead;
+        byte[] data = new byte[1024];
+
+        // Read data from InputStream in chunks of 1024 bytes
+        while ((nRead = inputStream.read(data, 0, data.length)) != -1) {
+            // Write the read data into ByteArrayOutputStream
+            buffer.write(data, 0, nRead);
+        }
+
+        // Return the complete byte array
+        return buffer.toByteArray();
     }
 }


### PR DESCRIPTION
-Implemented org.jupnp.util.io.IO#readAllBytes method to read all bytes from an InputStream, to be replaced by java.io.InputStream#readAllBytes when Android 13 (API Level 33) is more widely used.