### PR TITLE
Labeling enhancements

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,20 @@
+changelog:
+  categories:
+    - title: ⚠️ Security issues
+      labels:
+        - security
+    - title: ⭐ Enhancements
+      labels:
+        - enhancement
+    - title: 🐞 Bug fixes
+      labels:
+        - bug
+    - title: 🔨 Dependency upgrades
+      labels:
+        - dependencies
+    - title: 📝 Documentation
+      labels:
+        - documentation
+    - title: Other changes
+      labels:
+        - "*"

--- a/.github/workflows/stale-issues.yml
+++ b/.github/workflows/stale-issues.yml
@@ -1,0 +1,27 @@
+name: 'Stale issues check'
+
+on:
+  schedule:
+    - cron: '30 1 * * *'
+  workflow_dispatch:
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    name: Stale issues check
+    permissions:
+      issues: write
+    steps:
+      - name: Stale issues check
+        uses: actions/stale@v9
+        with:
+          days-before-issue-stale: 60
+          days-before-issue-close: 180
+          days-before-pr-stale: -1
+          days-before-pr-close: -1
+          only-labels: 'awaiting feedback'
+          stale-issue-label: 'stale'
+          exempt-issue-labels: 'pinned,security,PR pending'
+          stale-issue-message: >-
+            This issue has been automatically marked as stale because it has not had recent activity.
+            It will be closed if no further activity occurs. Thank you for your contributions.


### PR DESCRIPTION
* Use labels when generating release notes
* Add GHA workflow for stale issues

See:

* https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes
* https://github.com/actions/stale