### PR TITLE
Fix Iterators::remove() in case more than one element is removed

### DIFF
--- a/bundles/org.jupnp/src/main/java/org/jupnp/util/Iterators.java
+++ b/bundles/org.jupnp/src/main/java/org/jupnp/util/Iterators.java
@@ -87,6 +87,7 @@ public class Iterators {
         final Iterator<E> wrapped;
 
         int nextIndex = 0;
+        int removedCount = 0;
         boolean removedCurrent = false;
 
         protected Synchronized(Collection<E> collection) {
@@ -113,7 +114,8 @@ public class Iterators {
             if (removedCurrent) {
                 throw new IllegalStateException("Already removed current, call next()");
             }
-            synchronizedRemove(nextIndex - 1);
+            synchronizedRemove(nextIndex - 1 - removedCount);
+            removedCount++;
             removedCurrent = true;
         }
 

--- a/bundles/org.jupnp/src/test/java/org/jupnp/transport/SynchronizedIteratorTest.java
+++ b/bundles/org.jupnp/src/test/java/org/jupnp/transport/SynchronizedIteratorTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2011-2026 4th Line GmbH, Switzerland and others
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License Version 1 or later
+ * ("CDDL") (collectively, the "License"). You may not use this file
+ * except in compliance with the License. See LICENSE.txt for more
+ * information.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * SPDX-License-Identifier: CDDL-1.0
+ */
+package org.jupnp.transport;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.net.InetAddress;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.jupnp.util.Iterators;
+
+/**
+ * @author Holger Friedrich - initial contribution
+ */
+class SynchronizedIteratorTest {
+
+    @Test
+    void testSynchronizedIteratorRemoveAll() {
+        List<InetAddress> bindAddresses = new ArrayList<>();
+        bindAddresses.add(InetAddress.getLoopbackAddress());
+        bindAddresses.add(InetAddress.getLoopbackAddress());
+
+        var synced = new Iterators.Synchronized<>(bindAddresses) {
+            @Override
+            protected void synchronizedRemove(int index) {
+                synchronized (bindAddresses) {
+                    bindAddresses.remove(index);
+                }
+            }
+        };
+
+        assertTrue(synced.hasNext());
+        synced.next();
+        synced.remove();
+
+        assertTrue(synced.hasNext());
+        synced.next();
+        synced.remove();
+
+        assertFalse(synced.hasNext());
+        assertTrue(bindAddresses.isEmpty());
+    }
+}


### PR DESCRIPTION
This PR adds a test for `Iterators.Synchronized.remove()` method and adapts the implementation to let the test pass.

It seems that without the change, the index of the underlying set is not computed correctly. See this stack trace from openHAB:

<details>

~~~
java.lang.IndexOutOfBoundsException: Index 1 out of bounds for length 1
	at java.base/jdk.internal.util.Preconditions.outOfBounds(Preconditions.java:100)
	at java.base/jdk.internal.util.Preconditions.outOfBoundsCheckIndex(Preconditions.java:106)
	at java.base/jdk.internal.util.Preconditions.checkIndex(Preconditions.java:302)
	at java.base/java.util.Objects.checkIndex(Objects.java:385)
	at java.base/java.util.ArrayList.remove(ArrayList.java:551)
	at org.jupnp.transport.impl.NetworkAddressFactoryImpl$2.synchronizedRemove(NetworkAddressFactoryImpl.java:178)
	at org.jupnp.util.Iterators$Synchronized.remove(Iterators.java:116)
	at org.jupnp.transport.RouterImpl.startAddressBasedTransports(RouterImpl.java:410)
	at org.jupnp.transport.RouterImpl.enable(RouterImpl.java:127)
	at org.jupnp.UpnpServiceImpl.startup(UpnpServiceImpl.java:263)
	at org.jupnp.UpnpServiceImpl.activate(UpnpServiceImpl.java:100)
	...
~~~

</details>

The test is adding two elements in the style it would be used in the code, and then removed both. Without the change to implementation, the test fails.

I am not sure if this is the way to fix this issue properly.