### PR TITLE
Reduce runtime vulnerabilties

### DIFF
--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -17,7 +17,7 @@
   <properties>
     <basedirRoot>../..</basedirRoot>
     <maven.deploy.skip>true</maven.deploy.skip>
-    <pax.logging.version>2.2.7</pax.logging.version>
+    <pax.logging.version>2.3.4</pax.logging.version>
     <pax.web.version>8.0.25</pax.web.version>
   </properties>
 
@@ -90,6 +90,12 @@
       <groupId>org.ops4j.pax.web</groupId>
       <artifactId>pax-web-jetty</artifactId>
       <version>${pax.web.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.directory.api</groupId>
+          <artifactId>api-ldap-model</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.ops4j.pax.web</groupId>

--- a/itests/org.jupnp.osgi.tests/itest.bndrun
+++ b/itests/org.jupnp.osgi.tests/itest.bndrun
@@ -33,7 +33,7 @@
 	org.eclipse.jetty.util;version='[9.4.53,9.4.54)',\
 	org.eclipse.jetty.util.ajax;version='[9.4.53,9.4.54)',\
 	org.eclipse.jetty.xml;version='[9.4.53,9.4.54)',\
-	org.ops4j.pax.logging.pax-logging-api;version='[2.2.7,2.2.8)',\
+	org.ops4j.pax.logging.pax-logging-api;version='[2.3.4,2.3.5)',\
 	org.ops4j.pax.web.pax-web-api;version='[8.0.25,8.0.26)',\
 	org.ops4j.pax.web.pax-web-jetty;version='[8.0.25,8.0.26)',\
 	org.ops4j.pax.web.pax-web-runtime;version='[8.0.25,8.0.26)',\


### PR DESCRIPTION
- Upgrade Pax Logging from `2.2.7` to `2.3.4`.
- Exclude the unused LDAP model from Pax Web to avoid pulling in Apache MINA and its known vulnerabilities transitively.
- Align the OSGi integration test runtime with the updated version.