### PR TITLE
Fix Android UPnP service startup lifecycle

### DIFF
--- a/bundles/org.jupnp.android/src/main/java/org/jupnp/android/AndroidUpnpServiceImpl.java
+++ b/bundles/org.jupnp.android/src/main/java/org/jupnp/android/AndroidUpnpServiceImpl.java
@@ -65,14 +65,19 @@ public class AndroidUpnpServiceImpl extends Service {
             public synchronized void shutdown() {
                 // First have to remove the receiver, so Android won't complain about it leaking
                 // when the main UI thread exits.
-                ((AndroidRouter) getRouter()).unregisterBroadcastReceiver();
+                AndroidRouter router = (AndroidRouter) getRouter();
+                if (router != null) {
+                    router.unregisterBroadcastReceiver();
+                }
 
-                // Now we can concurrently run the Cling shutdown code, without occupying the
+                // Now we can concurrently run the jUPnP shutdown code, without occupying the
                 // Android main UI thread. This will complete probably after the main UI thread
                 // is done.
                 super.shutdown(true);
             }
         };
+
+        upnpService.startup();
     }
 
     protected UpnpServiceConfiguration createConfiguration() {


### PR DESCRIPTION
The constructor no longer started the UPnP stack. Startup is normally triggered through the OSGi activation lifecycle, which is not used by the Android service. As a result, the registry, router, control point, network transports, and initial device search were never initialized when using the default Android service implementation.

Fixes #273