### PR TITLE
Configure weekly Dependabot updates for website dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,24 @@ updates:
     labels:
       - dependencies
 
+  - package-ecosystem: "npm" # See documentation for possible values
+    directory: "/website" # Location of package manifests
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    labels:
+      - dependencies
+    groups:
+      docusaurus:
+        patterns:
+          - "@docusaurus/*"
+      website-dependencies:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+
   - package-ecosystem: "maven" # See documentation for possible values
     directory: "/" # Location of package manifests
     schedule:


### PR DESCRIPTION
This adds weekly Dependabot version updates for the website dependencies in `/website`.

The configuration:

- groups all `@docusaurus/*` updates together, since these packages are generally upgraded in sync;
- groups other minor and patch updates into a single weekly pull request;
- keeps unrelated major version updates in separate pull requests;
- applies the existing `dependencies` label and a limit of 10 open pull requests.

This should reduce the number of individual website dependency pull requests while keeping potentially breaking upgrades easier to review.