### PR TITLE
Add Maven Central release and snapshot publishing

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -16,6 +16,9 @@ on:
 permissions:
   contents: read
 
+env:
+  MAVEN_OPTS: -Xmx2g -Dmaven.wagon.http.retryHandler.count=5 -Dmaven.wagon.httpconnectionManager.ttlSeconds=25
+
 jobs:
   build:
     strategy:
@@ -50,13 +53,7 @@ jobs:
           cache: 'maven'
 
       - name: Build
-        run: ${{ matrix.maven_command || './mvnw' }} clean verify -B -U
-        env:
-          MAVEN_OPTS: >-
-            -Xmx2g
-            -Dmaven.wagon.http.retryHandler.count=5
-            -Dmaven.wagon.httpconnectionManager.ttlSeconds=25
-            -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
+        run: ${{ matrix.maven_command || './mvnw' }} -B -ntp -U clean verify
 
       - name: Verify Changed Files
         id: verify-changed-files
@@ -73,3 +70,31 @@ jobs:
         run: |
           echo "::error::Files have changed: $CHANGED_FILES"
           exit 1
+
+  publish-snapshot:
+    name: Publish snapshot
+    if: github.ref == 'refs/heads/main'
+    needs: build
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Set up Java 11 and Maven Central credentials
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: '11'
+          cache: maven
+          server-id: central
+          server-username: CENTRAL_USERNAME
+          server-password: CENTRAL_PASSWORD
+
+      - name: Publish snapshot
+        env:
+          CENTRAL_USERNAME: ${{ secrets.CENTRAL_USERNAME }}
+          CENTRAL_PASSWORD: ${{ secrets.CENTRAL_PASSWORD }}
+        run: ./mvnw -B -ntp clean deploy -DskipTests

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,222 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_version:
+        description: Release version (for example, 3.0.5)
+        required: true
+        type: string
+      next_snapshot_version:
+        description: Next snapshot version (for example, 3.0.6-SNAPSHOT)
+        required: true
+        type: string
+
+permissions:
+  actions: write
+  contents: write
+
+concurrency:
+  group: release
+  cancel-in-progress: false
+
+defaults:
+  run:
+    shell: bash
+
+env:
+  RELEASE_VERSION: ${{ inputs.release_version }}
+  NEXT_SNAPSHOT_VERSION: ${{ inputs.next_snapshot_version }}
+  TAG_NAME: ${{ inputs.release_version }}
+  DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+  MAVEN_OPTS: -Xmx2g -Dmaven.wagon.http.retryHandler.count=5 -Dmaven.wagon.httpconnectionManager.ttlSeconds=25
+
+jobs:
+  prepare-release:
+    name: Prepare release
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Checkout default branch
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ env.DEFAULT_BRANCH }}
+          fetch-depth: 0
+          token: ${{ github.token }}
+
+      - name: Set up Java 11
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: '11'
+          cache: maven
+
+      - name: Validate release inputs
+        run: |
+          if [[ ! "$RELEASE_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Invalid release version: $RELEASE_VERSION"
+            exit 1
+          fi
+
+          if [[ ! "$NEXT_SNAPSHOT_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+-SNAPSHOT$ ]]; then
+            echo "::error::Invalid next snapshot version: $NEXT_SNAPSHOT_VERSION"
+            exit 1
+          fi
+
+          current_version="$(./mvnw -B -ntp help:evaluate -Dexpression=project.version -q -DforceStdout)"
+
+          expected_version="${RELEASE_VERSION}-SNAPSHOT"
+
+          if [[ "$current_version" != "$expected_version" ]]; then
+            echo "::error::Expected current version $expected_version, but found $current_version"
+            exit 1
+          fi
+
+          if git ls-remote --exit-code --tags origin "refs/tags/$TAG_NAME" >/dev/null 2>&1
+          then
+            echo "::error::Tag $TAG_NAME already exists"
+            exit 1
+          fi
+
+      - name: Set release version
+        run: ./mvnw -B -ntp versions:set -DnewVersion="$RELEASE_VERSION" -DprocessAllModules=true -DgenerateBackupPoms=false
+
+      - name: Verify release build and update runbundles
+        run: ./mvnw -B -ntp clean install -DwithResolver -DskipTests
+
+      - name: Validate release changes
+        run: |
+          git diff --check
+
+          unexpected_files="$(git diff --name-only | grep -vE '(^|/)pom\.xml$|^itests/.*\.bndrun$' || true)"
+          if [[ -n "$unexpected_files" ]]; then
+            echo "::error::Release preparation changed unexpected files:"
+            echo "$unexpected_files"
+            exit 1
+          fi
+
+          untracked_files="$(git ls-files --others --exclude-standard)"
+          if [[ -n "$untracked_files" ]]; then
+            echo "::error::Release preparation created untracked files:"
+            echo "$untracked_files"
+            exit 1
+          fi
+
+          git add -u -- .
+
+      - name: Commit and tag release
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git commit -m "Release version $RELEASE_VERSION"
+          git tag -a "$TAG_NAME" -m "Release version $RELEASE_VERSION"
+          git push --atomic origin "HEAD:$DEFAULT_BRANCH" "$TAG_NAME"
+
+  publish:
+    name: Publish to Maven Central
+    needs: prepare-release
+    runs-on: ubuntu-24.04
+    timeout-minutes: 90
+
+    steps:
+      - name: Checkout release tag
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ env.TAG_NAME }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Set up Java 11 and Maven Central credentials
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: '11'
+          cache: maven
+          server-id: central
+          server-username: CENTRAL_USERNAME
+          server-password: CENTRAL_PASSWORD
+          gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
+          gpg-passphrase: GPG_PASSPHRASE
+
+      - name: Publish release
+        env:
+          CENTRAL_USERNAME: ${{ secrets.CENTRAL_USERNAME }}
+          CENTRAL_PASSWORD: ${{ secrets.CENTRAL_PASSWORD }}
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+        run: ./mvnw -B -ntp clean deploy -DsignArtifacts -DskipTests
+
+  finalize-release:
+    name: Create GitHub release and next snapshot
+    needs: publish
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Checkout default branch
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ env.DEFAULT_BRANCH }}
+          fetch-depth: 0
+          token: ${{ github.token }}
+
+      - name: Set up Java 11
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: '11'
+          cache: maven
+
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          if ! gh release view "$TAG_NAME" >/dev/null 2>&1; then
+            gh release create "$TAG_NAME" --verify-tag --generate-notes --title "JUPnP $RELEASE_VERSION"
+          fi
+
+      - name: Set next snapshot version
+        run: |
+          current_version="$(./mvnw -B -ntp help:evaluate -Dexpression=project.version -q -DforceStdout)"
+          if [[ "$current_version" != "$RELEASE_VERSION" ]]; then
+            echo "::error::Expected current version $RELEASE_VERSION, but found $current_version"
+            exit 1
+          fi
+          ./mvnw -B -ntp versions:set -DnewVersion="$NEXT_SNAPSHOT_VERSION" -DprocessAllModules=true -DgenerateBackupPoms=false
+
+      - name: Update runbundles
+        run: ./mvnw -B -ntp clean install -DwithResolver -DskipTests
+
+      - name: Validate snapshot changes
+        run: |
+          git diff --check
+
+          unexpected_files="$(git diff --name-only | grep -vE '(^|/)pom\.xml$|^itests/.*\.bndrun$' || true)"
+
+          if [[ -n "$unexpected_files" ]]; then
+            echo "::error::Snapshot preparation changed unexpected files:"
+            echo "$unexpected_files"
+            exit 1
+          fi
+
+          untracked_files="$(git ls-files --others --exclude-standard)"
+
+          if [[ -n "$untracked_files" ]]; then
+            echo "::error::Snapshot preparation created untracked files:"
+            echo "$untracked_files"
+            exit 1
+          fi
+
+          git add -u -- .
+
+      - name: Commit next snapshot version
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git commit -m "Prepare for next development iteration: $NEXT_SNAPSHOT_VERSION"
+          git push origin "HEAD:$DEFAULT_BRANCH"
+
+      - name: Trigger snapshot build
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+        run: gh workflow run ci-build.yml --ref "$DEFAULT_BRANCH"

--- a/pom.xml
+++ b/pom.xml
@@ -52,13 +52,6 @@
     <system>github</system>
     <url>https://github.com/jupnp/jupnp/issues</url>
   </issueManagement>
-  <distributionManagement>
-    <repository>
-      <uniqueVersion>false</uniqueVersion>
-      <id>ossrh</id>
-      <url>https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2/</url>
-    </repository>
-  </distributionManagement>
 
   <properties>
     <basedirRoot>.</basedirRoot>
@@ -209,6 +202,35 @@
           <version>3.6.1</version>
         </plugin>
         <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>versions-maven-plugin</artifactId>
+          <version>2.21.0</version>
+        </plugin>
+        <plugin>
+          <groupId>org.sonatype.central</groupId>
+          <artifactId>central-publishing-maven-plugin</artifactId>
+          <version>0.11.0</version>
+          <extensions>true</extensions>
+          <configuration>
+            <publishingServerId>central</publishingServerId>
+            <autoPublish>false</autoPublish>
+            <!--
+            <autoPublish>true</autoPublish>
+            <waitUntil>published</waitUntil>
+            <waitMaxTime>3600</waitMaxTime>
+            -->
+            <excludeArtifacts>
+              <artifact>org.jupnp.bom.runtime</artifact>
+              <artifact>org.jupnp.bom.runtime-index</artifact>
+              <artifact>org.jupnp.bom.test-index</artifact>
+              <artifact>itests</artifact>
+              <artifact>org.jupnp.common</artifact>
+              <artifact>org.jupnp.device.simple</artifact>
+              <artifact>org.jupnp.osgi.tests</artifact>
+            </excludeArtifacts>
+          </configuration>
+        </plugin>
+        <plugin>
           <groupId>com.diffplug.spotless</groupId>
           <artifactId>spotless-maven-plugin</artifactId>
           <version>${spotless.version}</version>
@@ -294,6 +316,10 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.sonatype.central</groupId>
+        <artifactId>central-publishing-maven-plugin</artifactId>
+      </plugin>
     </plugins>
   </build>
 
@@ -309,11 +335,12 @@
         <bndFile>bnd.bnd</bndFile>
       </properties>
     </profile>
+
     <profile>
-      <id>release-sign-artifacts</id>
+      <id>sign-artifacts</id>
       <activation>
         <property>
-          <name>performRelease</name>
+          <name>signArtifacts</name>
           <value>true</value>
         </property>
       </activation>

--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -68,6 +68,18 @@
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>attach-javadocs</id>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-source-plugin</artifactId>
         <executions>
           <execution>
@@ -75,7 +87,6 @@
             <goals>
               <goal>jar-no-fork</goal>
             </goals>
-            <phase>verify</phase>
           </execution>
         </executions>
       </plugin>


### PR DESCRIPTION
* Configure Central Portal publishing and artifact signing
* Publish snapshots from CI after successful builds
* Add a manual release workflow with version bumps and generated GitHub releases
* Update resolved Bnd runbundles for release and next snapshot versions

---

I tested this in my fork and it works very well:

* [GHA deploys snapshots on main branch events](https://github.com/wborn/jupnp/actions/runs/31185064696) 
* [GHA can release to Maven Central](https://github.com/wborn/jupnp/actions/runs/31186321047)
* [Versions are properly updated (including the itest runbundles)](https://github.com/wborn/jupnp/commits/main/)
* [A tag is created with the correct versions](https://github.com/wborn/jupnp/releases/tag/3.0.5)
* [There is a GitHub release](https://github.com/wborn/jupnp/releases/tag/3.0.5) (no release notes because my fork does not have all those PRs)
* [A deployment gets created on Maven Central](https://central.sonatype.com/publishing/deployments)
  The deployment is properly validated and would get published after clicking the **Publish** button.
  It can also automatically publish it when we don't run into any issues using the [commented configuration](https://github.com/jupnp/jupnp/compare/main...wborn:add-maven-central-publishing?expand=1#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8R217)
* [It triggers a build after the release to publish the new snapshot](https://github.com/wborn/jupnp/actions/runs/31186635881) (which I cancelled) 

I already setup the GHA secrets for this to work.
We can also change it to use your secrets @kaikreuzer.
That way the artifacts would still be signed with the same key.