### PR TITLE
Update Java build matrix and Bnd tooling

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -24,10 +24,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [ '11' ]
-        os: [ 'macos-26', 'ubuntu-24.04', 'windows-2025' ]
+        java: [ '11', '17', '21', '25', '26' ]
+        os: [ 'ubuntu-24.04' ]
         include:
-          - os: windows-2025
+          - java: '11'
+            os: 'macos-26'
+          - java: '11'
+            os: 'windows-2025'
             maven_command: .\mvnw.cmd
 
     name: Build (Java ${{ matrix.java }}, ${{ matrix.os }})
@@ -83,11 +86,11 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Set up Java 11 and Maven Central credentials
+      - name: Set up Java 17 and Maven Central credentials
         uses: actions/setup-java@v5
         with:
           distribution: temurin
-          java-version: '11'
+          java-version: '17'
           cache: maven
           server-id: central
           server-username: CENTRAL_USERNAME

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,11 +44,11 @@ jobs:
           fetch-depth: 0
           token: ${{ github.token }}
 
-      - name: Set up Java 11
+      - name: Set up Java 17
         uses: actions/setup-java@v5
         with:
           distribution: temurin
-          java-version: '11'
+          java-version: '17'
           cache: maven
 
       - name: Validate release inputs
@@ -126,11 +126,11 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - name: Set up Java 11 and Maven Central credentials
+      - name: Set up Java 17 and Maven Central credentials
         uses: actions/setup-java@v5
         with:
           distribution: temurin
-          java-version: '11'
+          java-version: '17'
           cache: maven
           server-id: central
           server-username: CENTRAL_USERNAME
@@ -158,11 +158,11 @@ jobs:
           fetch-depth: 0
           token: ${{ github.token }}
 
-      - name: Set up Java 11
+      - name: Set up Java 17
         uses: actions/setup-java@v5
         with:
           distribution: temurin
-          java-version: '11'
+          java-version: '17'
           cache: maven
 
       - name: Create GitHub release

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,10 @@
 .classpath
-.idea
+.idea/
 .project
 .DS_Store
-.settings
-.vscode
-target
+.settings/
+.vscode/
+generated/
+target/
 *.iml
+

--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,3 @@
 generated/
 target/
 *.iml
-

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The build infrastructure is based on Maven and includes the Maven Wrapper,
 so you do not need to install Maven separately.
 
 What you need before you start:
-- Java SDK 11 (please note that the build does NOT work with any higher version!)
+- Java SDK 11 or newer
 
 ### Checkout
 

--- a/README.md
+++ b/README.md
@@ -32,8 +32,7 @@ You can usually install a JDK using your operating system's package manager, for
 - RHEL/Fedora: `java-21-openjdk-devel`
 
 Package names may differ depending on the Java version and distribution.
-If a suitable JDK is not available from your operating system, you can use
-[Eclipse Temurin](https://adoptium.net/temurin/releases/), which is also used by the CI builds.
+If a suitable JDK is not available from your operating system, you can use [Eclipse Temurin](https://adoptium.net/temurin/releases/), which is also used by the CI builds.
 
 ### Checkout
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,15 @@ The build infrastructure is based on Maven and includes the Maven Wrapper,
 so you do not need to install Maven separately.
 
 What you need before you start:
-- Java SDK 11 or newer
+- Java Development Kit (JDK) 11 or newer
+
+You can usually install a JDK using your operating system's package manager, for example:
+- Debian/Ubuntu: `openjdk-21-jdk`
+- RHEL/Fedora: `java-21-openjdk-devel`
+
+Package names may differ depending on the Java version and distribution.
+If a suitable JDK is not available from your operating system, you can use
+[Eclipse Temurin](https://adoptium.net/temurin/releases/), which is also used by the CI builds.
 
 ### Checkout
 

--- a/itests/itest-common.bndrun
+++ b/itests/itest-common.bndrun
@@ -11,7 +11,7 @@
 Test-Cases: ${classes;CONCRETE;PUBLIC;NAMED;*Test}
 
 -runfw: org.eclipse.osgi
--runee: JavaSE-11
+-runee: ${bnd.testing.runee}
 
 # An unused random HTTP port is used during tests to prevent resource conflicts
 # This property is set by the build-helper-maven-plugin in the itests pom.xml

--- a/itests/org.jupnp.osgi.tests/itest.bndrun
+++ b/itests/org.jupnp.osgi.tests/itest.bndrun
@@ -8,7 +8,7 @@
 # done
 #
 -runbundles: \
-	biz.aQute.tester.junit-platform;version='[6.4.0,6.4.1)',\
+	biz.aQute.tester.junit-platform;version='[7.3.0,7.3.1)',\
 	javax.servlet-api;version='[3.1.0,3.1.1)',\
 	org.eclipse.equinox.event;version='[1.4.300,1.4.301)',\
 	org.opentest4j;version='[1.3.0,1.3.1)',\

--- a/itests/org.jupnp.osgi.tests/itest.bndrun
+++ b/itests/org.jupnp.osgi.tests/itest.bndrun
@@ -8,7 +8,7 @@
 # done
 #
 -runbundles: \
-	biz.aQute.tester.junit-platform;version='[7.3.0,7.3.1)',\
+	biz.aQute.tester.junit-platform;version='[7.4.0,7.4.1)',\
 	javax.servlet-api;version='[3.1.0,3.1.1)',\
 	org.eclipse.equinox.event;version='[1.4.300,1.4.301)',\
 	org.opentest4j;version='[1.3.0,1.3.1)',\
@@ -41,5 +41,4 @@
 	org.ops4j.pax.web.pax-web-tomcat-common;version='[8.0.25,8.0.26)',\
 	org.jupnp;version='[3.0.6,3.0.7)',\
 	org.jupnp.device.simple;version='[3.0.6,3.0.7)',\
-	org.jupnp.osgi;version='[3.0.6,3.0.7)',\
-	org.jupnp.osgi.tests;version='[3.0.6,3.0.7)'
+	org.jupnp.osgi;version='[3.0.6,3.0.7)'

--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,7 @@
   <properties>
     <basedirRoot>.</basedirRoot>
     <bndFile>${basedirRoot}/bnd.bnd</bndFile>
+    <bnd.testing.resolve>true</bnd.testing.resolve>
     <maven.compiler.release>11</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
@@ -127,6 +128,10 @@
           <groupId>biz.aQute.bnd</groupId>
           <artifactId>bnd-testing-maven-plugin</artifactId>
           <version>${bnd.version}</version>
+          <configuration>
+            <resolve>${bnd.testing.resolve}</resolve>
+            <failOnChanges>false</failOnChanges>
+          </configuration>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -330,6 +335,7 @@
         <jdk>[17,)</jdk>
       </activation>
       <properties>
+        <bnd.testing.resolve>false</bnd.testing.resolve>
         <bnd.version>7.3.0</bnd.version>
       </properties>
     </profile>

--- a/pom.xml
+++ b/pom.xml
@@ -325,6 +325,16 @@
 
   <profiles>
     <profile>
+      <id>bnd-java17-plus</id>
+      <activation>
+        <jdk>[17,)</jdk>
+      </activation>
+      <properties>
+        <bnd.version>7.3.0</bnd.version>
+      </properties>
+    </profile>
+
+    <profile>
       <id>bnd-specific-profile</id>
       <activation>
         <file>

--- a/pom.xml
+++ b/pom.xml
@@ -339,7 +339,7 @@
       <properties>
         <bnd.testing.runee>JavaSE-17</bnd.testing.runee>
         <bnd.testing.resolve>false</bnd.testing.resolve>
-        <bnd.version>7.3.0</bnd.version>
+        <bnd.version>7.4.0</bnd.version>
       </properties>
     </profile>
 

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,6 @@
   <properties>
     <basedirRoot>.</basedirRoot>
     <bndFile>${basedirRoot}/bnd.bnd</bndFile>
-    <bnd.testing.resolve>true</bnd.testing.resolve>
     <maven.compiler.release>11</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
@@ -70,6 +69,9 @@
     <servlet.api.version>3.1.0</servlet.api.version>
     <slf4j.version>2.0.11</slf4j.version>
     <osgi.version>7.0.0</osgi.version>
+
+    <bnd.testing.runee>JavaSE-11</bnd.testing.runee>
+    <bnd.testing.resolve>true</bnd.testing.resolve>
 
     <spotless.version>2.44.3</spotless.version>
     <!-- Eclipse Java formatter version 4.26+ does not check test files -->
@@ -335,6 +337,7 @@
         <jdk>[17,)</jdk>
       </activation>
       <properties>
+        <bnd.testing.runee>JavaSE-17</bnd.testing.runee>
         <bnd.testing.resolve>false</bnd.testing.resolve>
         <bnd.version>7.3.0</bnd.version>
       </properties>

--- a/website/docs/introduction.md
+++ b/website/docs/introduction.md
@@ -21,7 +21,15 @@ The build infrastructure is based on Maven and includes the Maven Wrapper,
 so you do not need to install Maven separately.
 
 What you need before you start:
-- Java SDK 11 or newer
+- Java Development Kit (JDK) 11 or newer
+
+You can usually install a JDK using your operating system's package manager, for example:
+- Debian/Ubuntu: `openjdk-21-jdk`
+- RHEL/Fedora: `java-21-openjdk-devel`
+
+Package names may differ depending on the Java version and distribution.
+If a suitable JDK is not available from your operating system, you can use
+[Eclipse Temurin](https://adoptium.net/temurin/releases/), which is also used by the CI builds.
 
 ### Checkout
 

--- a/website/docs/introduction.md
+++ b/website/docs/introduction.md
@@ -21,7 +21,7 @@ The build infrastructure is based on Maven and includes the Maven Wrapper,
 so you do not need to install Maven separately.
 
 What you need before you start:
-- Java SDK 11 (please note that the build does NOT work with any higher version!)
+- Java SDK 11 or newer
 
 ### Checkout
 

--- a/website/docs/introduction.md
+++ b/website/docs/introduction.md
@@ -28,8 +28,7 @@ You can usually install a JDK using your operating system's package manager, for
 - RHEL/Fedora: `java-21-openjdk-devel`
 
 Package names may differ depending on the Java version and distribution.
-If a suitable JDK is not available from your operating system, you can use
-[Eclipse Temurin](https://adoptium.net/temurin/releases/), which is also used by the CI builds.
+If a suitable JDK is not available from your operating system, you can use [Eclipse Temurin](https://adoptium.net/temurin/releases/), which is also used by the CI builds.
 
 ### Checkout
 


### PR DESCRIPTION
This updates the CI build matrix to test jUPnP with Java 11, 17, 21, 25, and 26.

Java 11 remains the minimum supported Java version and continues to be tested on Linux, macOS, and Windows. Newer Java versions are tested on Linux to provide coverage across the currently relevant LTS releases and the latest Java release without unnecessarily multiplying the number of CI jobs. The build documentation is updated accordingly to state that Java 11 or newer can be used.

Snapshot publishing and release workflows are changed from Java 11 to Java 17. Java 17 is the minimum JDK that can build the complete reactor once #365 is merged, while individual modules continue to use their configured `maven.compiler.release` levels.

The expanded Java matrix also exposed that Bnd 6.4.0 is not compatible with Java 24 and newer because its launcher uses the removed system-wide security policy mechanism. Bnd 7.4.0 contains the corresponding fix, but requires Java 17 or newer itself.

The build therefore keeps Bnd 6.4.0 for Java 11 and activates Bnd 7.3.0 when Maven runs on Java 17 or newer. The integration-test configuration handles both versions: Java 11 resolves the test run bundles in memory using the JavaSE-11 execution environment, while Java 17+ uses the Bnd 7.4.0 test bundles with the JavaSE-17 execution environment.

This preserves Java 11 build compatibility while allowing the project to build and test successfully with current JDKs and prepares the snapshot and release workflows for #365.